### PR TITLE
Fix #304 (omni-compiler):  incompatible type for function return var

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -2312,7 +2312,9 @@ declare_id_type(ID id, TYPE_DESC tp)
             if (TYPE_REF(tpp) != NULL 
                 && !type_is_soft_compatible(tq, TYPE_REF(tpp))) 
             {
-                if(TYPE_BASIC_TYPE(TYPE_REF(tpp)) == TYPE_FUNCTION) {
+                if(type_is_specific_than(tq, TYPE_REF(tpp)) 
+                    || TYPE_BASIC_TYPE(TYPE_REF(tpp)) == TYPE_FUNCTION) 
+                {
                     TYPE_REF(tpp) = tq;
                 } else {
                     goto no_compatible;

--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -2309,11 +2309,15 @@ declare_id_type(ID id, TYPE_DESC tp)
             tpp = tp;
             while(TYPE_REF(tpp) != NULL && IS_ARRAY_TYPE(TYPE_REF(tpp)))
                 tpp = TYPE_REF(tpp);
-            if (TYPE_REF(tpp) != NULL && !type_is_soft_compatible(tq, TYPE_REF(tpp)))
-                goto no_compatible;
-            if (TYPE_REF(tpp) == NULL ||
-                type_is_specific_than(tq, TYPE_REF(tpp)))
-                TYPE_REF(tpp) = tq;
+            if (TYPE_REF(tpp) != NULL 
+                && !type_is_soft_compatible(tq, TYPE_REF(tpp))) 
+            {
+                if(TYPE_BASIC_TYPE(TYPE_REF(tpp)) == TYPE_FUNCTION) {
+                    TYPE_REF(tpp) = tq;
+                } else {
+                    goto no_compatible;
+                }
+            }
         }
         *id_type = tp;
         return;

--- a/F-FrontEnd/test/failtestdata/issue304.f90
+++ b/F-FrontEnd/test/failtestdata/issue304.f90
@@ -1,0 +1,3 @@
+real function f()
+  integer, dimension(10) :: f
+end function f

--- a/F-FrontEnd/test/testdata/issue304.f90
+++ b/F-FrontEnd/test/testdata/issue304.f90
@@ -1,0 +1,16 @@
+module mod1
+integer, parameter :: fld_size = 10
+  
+contains
+
+  function fct1()
+    real, dimension(10) :: fct1 
+  end function fct1
+
+
+  real(kind=8) function fld_fr()
+    dimension :: fld_fr(fld_size)
+ 
+  end function fld_fr
+
+end module mod1


### PR DESCRIPTION
Fix for omni-compiler/omni-compiler#304