### PR TITLE
Fix #19: If derived type is TARGET, pointee does not need to be flagged as TARGET

### DIFF
--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -7987,9 +7987,12 @@ pointer_assignable(expr x,
     } else {
         // If derived type is TARGET, pointee doesn't need to be flagged as 
         // TARGET. xcodeml-tools#19
-        TYPE_DESC structType = vPointee != NULL ? 
+        TYPE_DESC structType = NULL;
+        if(EXPV_CODE(vPointee) == F95_MEMBER_REF) {
+            structType = vPointee != NULL ? 
             EXPV_LEFT(vPointee) != NULL ? EXPV_TYPE(EXPV_LEFT(vPointee)) : NULL
             : NULL;
+        }
         
         if (!TYPE_IS_TARGET(vPteTyp) &&
             !TYPE_IS_POINTER(vPteTyp) &&

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -7985,10 +7985,17 @@ pointer_assignable(expr x,
         }
 
     } else {
+        // If derived type is TARGET, pointee doesn't need to be flagged as 
+        // TARGET. xcodeml-tools#19
+        TYPE_DESC structType = EXPV_LEFT(vPointee) != NULL 
+            ? EXPV_TYPE(EXPV_LEFT(vPointee)) : NULL;
+        
         if (!TYPE_IS_TARGET(vPteTyp) &&
             !TYPE_IS_POINTER(vPteTyp) &&
             !IS_PROCEDURE_TYPE(vPteTyp) &&
-            !IS_ARRAY_TYPE(vPteTyp)) {
+            !IS_ARRAY_TYPE(vPteTyp) && 
+            (structType != NULL && !TYPE_IS_TARGET(structType))) // #19
+        {
             if (EXPR_CODE(EXPR_ARG2(x)) == IDENT) {
                 if (x) error_at_node(x, "'%s' is not a pointee.",
                                      SYM_NAME(EXPR_SYM(EXPR_ARG2(x))));

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -7987,8 +7987,9 @@ pointer_assignable(expr x,
     } else {
         // If derived type is TARGET, pointee doesn't need to be flagged as 
         // TARGET. xcodeml-tools#19
-        TYPE_DESC structType = EXPV_LEFT(vPointee) != NULL 
-            ? EXPV_TYPE(EXPV_LEFT(vPointee)) : NULL;
+        TYPE_DESC structType = vPointee != NULL ? 
+            EXPV_LEFT(vPointee) != NULL ? EXPV_TYPE(EXPV_LEFT(vPointee)) : NULL
+            : NULL;
         
         if (!TYPE_IS_TARGET(vPteTyp) &&
             !TYPE_IS_POINTER(vPteTyp) &&

--- a/F-FrontEnd/test/testdata/issue19.f90
+++ b/F-FrontEnd/test/testdata/issue19.f90
@@ -1,0 +1,22 @@
+MODULE mod1
+  IMPLICIT NONE
+  PRIVATE
+
+  TYPE t_lnd_prog
+  END TYPE t_lnd_prog
+  
+  TYPE t_lnd_state
+    TYPE(t_lnd_prog), ALLOCATABLE  :: prog_lnd(:)
+  END TYPE t_lnd_state
+
+CONTAINS
+
+  SUBROUTINE save_initial_state(p_lnd)
+    TYPE(t_lnd_state), TARGET, INTENT(IN) :: p_lnd(:)
+    INTEGER :: jg
+
+    TYPE(t_lnd_prog), POINTER :: lnd_prog
+
+    lnd_prog => p_lnd(jg)%prog_lnd(1)
+  END SUBROUTINE save_initial_state
+END MODULE mod1


### PR DESCRIPTION
Fix #19 