### PR TITLE
Fix #35:  Fix problem with undefined function used as argument

### DIFF
--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -514,7 +514,8 @@ compile_expression(expr x)
                 return compile_struct_constructor(id, NULL, EXPR_ARG2(x));
             }
 
-            if(!IS_ARRAY_TYPE(tp)) {
+            if(!IS_ARRAY_TYPE(tp) && !IS_FUNCTION_TYPE(tp)) {
+                // probably an undefined function passed as argument
                 sp_check(id);
                 ID_IS_DECLARED(id) = FALSE;
                 switch_id_to_proc(id);

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -515,6 +515,7 @@ compile_expression(expr x)
             }
 
             if(!IS_ARRAY_TYPE(tp)) {
+                sp_check(id);
                 ID_IS_DECLARED(id) = FALSE;
                 switch_id_to_proc(id);
                 return compile_function_call(id, EXPR_ARG2(x));

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -1833,14 +1833,15 @@ compile_array_ref(ID id, expv vary, expr args, int isLeft) {
         tp = FUNCTION_TYPE_RETURN_TYPE(tp);
     }
 
-    nDims = TYPE_N_DIM(tp);
-
-    if (!IS_ARRAY_TYPE(tp)){ //fatal("%s: not ARRAY_TYPE", __func__);
+    if (!IS_ARRAY_TYPE(tp)){
       error_at_id(id, "identifier '%s' is not of array type", ID_NAME(id));
       return NULL;
     }
-    if (!TYPE_DIM_FIXED(tp)) fix_array_dimensions(tp);
+    
+    nDims = TYPE_N_DIM(tp);
 
+    if (!TYPE_DIM_FIXED(tp)) fix_array_dimensions(tp);
+    
     /*
      * Firstly, check the # of subsctipts.
      */

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -4,6 +4,7 @@
 
 #include "F-front.h"
 #include "F-second-pass.h"
+#include "F-second-pass.h"
 #include <math.h>
 
 static expv compile_data_args _ANSI_ARGS_((expr args));
@@ -331,6 +332,14 @@ are_dimension_and_shape_conformant(expr x,
     return are_dimension_and_shape_conformant_by_type(x, lt, rt, shapePtr, for_argument, TRUE);
 }
 
+static void
+switch_id_to_proc(ID id)
+{
+    if(ID_CLASS(id) == CL_PROC)
+        return;
+    memset(&id->info.proc_info, 0, sizeof(id->info.proc_info));
+    ID_CLASS(id) = CL_PROC;
+}
 
 enum binary_expr_type {
     ARITB,
@@ -503,6 +512,12 @@ compile_expression(expr x)
 	      
             if (ID_CLASS(id) == CL_TAGNAME) {
                 return compile_struct_constructor(id, NULL, EXPR_ARG2(x));
+            }
+
+            if(!IS_ARRAY_TYPE(tp)) {
+                ID_IS_DECLARED(id) = FALSE;
+                switch_id_to_proc(id);
+                return compile_function_call(id, EXPR_ARG2(x));
             }
             return compile_array_ref(id, NULL, EXPR_ARG2(x), FALSE);
         }

--- a/F-FrontEnd/src/F-second-pass.c
+++ b/F-FrontEnd/src/F-second-pass.c
@@ -47,6 +47,33 @@ void remove_sp_list(SP_LIST *list)
     list->err_no = 0;
 }
 
+/* Check potential flagged undefined variable that have been switch to proc */
+void sp_check(ID id) {
+    SP_LIST *list = sp_list_head;
+    SP_LIST *prev = NULL;
+    while(list) {
+        SP_LIST *next = list->next;
+        //printf("item %s\n", ID_NAME(list->info.id));
+        if(list->err_no == SP_ERR_UNDEF_TYPE_VAR) {
+            // ID was flagged, now proc so error can be removed
+            if(strcmp(ID_NAME(id), ID_NAME(list->info.id)) == 0) {
+              if(list == sp_list_head) {
+                // Item is the head. Point head to next element.
+                list->next = NULL;
+                sp_list_head = next;
+                free((void*)list);
+              } else {
+                // Item is in middle of the list or tail
+                prev->next = next;
+                free((void*)list);
+              }
+            }
+        }
+        prev = list;
+        list = next;
+    }
+}
+
 void sp_link_id(ID id, int err_no, lineno_info *line)
 {
   SP_LIST *list;

--- a/F-FrontEnd/src/F-second-pass.h
+++ b/F-FrontEnd/src/F-second-pass.h
@@ -10,6 +10,7 @@
 extern void second_pass_init();
 extern int second_pass();
 extern void sp_link_id(ID id, int err_no, lineno_info *line);
+extern void sp_check(ID id);
 extern void sp_link_expr(expr ep, int err_no, lineno_info *line);
 
 #endif

--- a/F-FrontEnd/test/testdata/issue35.f90
+++ b/F-FrontEnd/test/testdata/issue35.f90
@@ -1,0 +1,32 @@
+MODULE mo_sw_test
+  IMPLICIT NONE
+  PRIVATE
+  PUBLIC :: init_will3_test
+
+  CONTAINS
+
+  SUBROUTINE init_will3_test ()
+    IMPLICIT NONE
+    REAL :: z_rotlat, z_uu, z_hh, u0
+    
+    z_hh = geostr_balance(symmetric_u_velo)
+    z_uu = symmetric_u_velo(z_rotlat, u0) * z_uu
+  END SUBROUTINE init_will3_test
+
+  FUNCTION geostr_balance(func)  RESULT(p_hh)
+    INTERFACE                        ! selected function
+      FUNCTION func(p_t, u0) RESULT(p_vv)
+        REAL, INTENT(in) :: p_t, u0
+        REAL             :: p_vv
+      END FUNCTION func
+    END INTERFACE
+    REAL :: p_hh
+  END FUNCTION geostr_balance
+
+  FUNCTION symmetric_u_velo(p_rlatd, u0) RESULT (p_usres)
+    REAL,INTENT(in) :: p_rlatd, u0
+    REAL :: p_usres
+  END FUNCTION symmetric_u_velo
+END MODULE mo_sw_test
+
+

--- a/F-FrontEnd/test/testdata/issue35.f90
+++ b/F-FrontEnd/test/testdata/issue35.f90
@@ -3,6 +3,7 @@ MODULE mo_sw_test
   PRIVATE
   PUBLIC :: init_will3_test
 
+  PUBLIC :: symmetric_u_velo
   CONTAINS
 
   SUBROUTINE init_will3_test ()

--- a/F-FrontEnd/test/testdata/issue35_2.f90
+++ b/F-FrontEnd/test/testdata/issue35_2.f90
@@ -1,0 +1,33 @@
+MODULE mo_sw_test
+  IMPLICIT NONE
+  PRIVATE
+  PUBLIC :: init_will3_test
+
+  PUBLIC :: symmetric_u_velo
+  CONTAINS
+
+  SUBROUTINE init_will3_test ()
+    IMPLICIT NONE
+    REAL :: z_rotlat, z_uu, z_hh, u0
+    
+    z_hh = geostr_balance(symmetric_u_velo)
+    z_uu = symmetric_u_velo(z_rotlat, u0) * z_uu
+  END SUBROUTINE init_will3_test
+
+  FUNCTION geostr_balance(func)  RESULT(p_hh)
+    INTERFACE                        ! selected function
+      FUNCTION func(p_t, u0) RESULT(p_vv)
+        REAL, INTENT(in) :: p_t, u0
+        REAL             :: p_vv
+      END FUNCTION func
+    END INTERFACE
+    REAL :: p_hh
+  END FUNCTION geostr_balance
+
+  FUNCTION symmetric_u_velo(p_rlatd, u0) RESULT (p_usres)
+    REAL,INTENT(in) :: p_rlatd, u0
+    REAL :: p_usres
+  END FUNCTION symmetric_u_velo
+END MODULE mo_sw_test
+
+


### PR DESCRIPTION
#35 
@h-murai @shingo-s There is still an issue that I don't really know how to solve. The argument `symmetric_u_velo ` at line 12 in the test data is disappearing. This is due because of an unset type at line 942 in `F-compile-decl.c`. Do you have any idea how we can solve this problem properly? 

Just for your information, with this PR and all other open ones, I was able to parse completely the ICON code base. More than 700 files and about 500k LOC. This is a nice achievement for an open-source Fortran parser I think!