### PR TITLE
Switch the behavior of coarray module use insertion

### DIFF
--- a/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
+++ b/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
@@ -3676,7 +3676,7 @@ XfDecompileDomVisitor {
             // ========
             writer.incrementIndentLevel();
             typeManager.enterScope();
-            if (!XmOption.coarrayNoUseStatement()) {
+            if (XmOption.coarrayUseStatement()) {
               writer.writeToken("use xmpf_coarray_decl");
               writer.setupNewLine();
             }
@@ -3751,7 +3751,7 @@ XfDecompileDomVisitor {
 
             writer.incrementIndentLevel();
             typeManager.enterScope();
-            if (!XmOption.coarrayNoUseStatement()) {
+            if (XmOption.coarrayUseStatement()) {
                 writer.writeToken("use xmpf_coarray_decl");
                 writer.setupNewLine();
             }
@@ -4170,7 +4170,7 @@ XfDecompileDomVisitor {
             // ========
             writer.incrementIndentLevel();
             typeManager.enterScope();
-            if (!XmOption.coarrayNoUseStatement()) {
+            if (XmOption.coarrayUseStatement()) {
               writer.writeToken("use xmpf_coarray_decl");
               writer.setupNewLine();
             }

--- a/XcodeML-Common/src/xcodeml/util/XmBackEnd.java
+++ b/XcodeML-Common/src/xcodeml/util/XmBackEnd.java
@@ -103,7 +103,7 @@ public class XmBackEnd
         boolean addXml = false;
         int maxColumns = 0;
 
-        boolean coarray_noUseStmt = false;
+        boolean coarray_useStmt = false;
         for(int i = 0; i < args.length; ++i) {
             String arg = args[i];
             String narg = (i < args.length - 1) ? args[i + 1] : null;
@@ -131,8 +131,8 @@ public class XmBackEnd
                     } catch (NumberFormatException e) {
                         _error("invalid number after -w.");
                     }
-                } else if(arg.equals("-fcoarray-no-use-statement")) {       // TEMPORARY
-                    coarray_noUseStmt = true;
+                } else if(arg.equals("-fcoarray-use-statement")) {       // TEMPORARY
+                    coarray_useStmt = true;
                 } else if(arg.equals("--help") || arg.equals("-h")) {
                     _usage();
                     System.exit(1);
@@ -145,7 +145,7 @@ public class XmBackEnd
                 _error("Too many input files.");
             }
         }
-        XmOption.setCoarrayNoUseStatement(coarray_noUseStmt);
+        XmOption.setCoarrayUseStatement(coarray_useStmt);
 
         if(!_openInputFile())
             return 1;

--- a/XcodeML-Common/src/xcodeml/util/XmOption.java
+++ b/XcodeML-Common/src/xcodeml/util/XmOption.java
@@ -88,7 +88,7 @@ public class XmOption
     /** if supressing generation of USE statement for coarray runtime
      *  (TEMPORARY)
      */
-    private static boolean _coarrayNoUseStatement = false;  
+    private static boolean _coarrayUseStatement = false;  
 
     private XmOption()
     {
@@ -383,16 +383,16 @@ public class XmOption
     }
 
     /**
-     * Set/get suboption -fcoarray-no-use-statement (boolean)
+     * Set/get suboption -fcoarray-use-statement (boolean)
      */
-    public static void setCoarrayNoUseStatement(boolean coarrayNoUseStatement)
+    public static void setCoarrayUseStatement(boolean coarrayUseStatement)
     {
-        _coarrayNoUseStatement = coarrayNoUseStatement;
+        _coarrayUseStatement = coarrayUseStatement;
     }
 
-    public static boolean coarrayNoUseStatement()
+    public static boolean coarrayUseStatement()
     {
-        return _coarrayNoUseStatement;
+        return _coarrayUseStatement;
     }
 
 }


### PR DESCRIPTION
Suggestion for #40 

This would be also nice if we have a CI that can test the whole workflow like for Fortran e.g. 
```
f90 -> F_Front -> XcodeML -> F_Back -> f90 -> gfortran -> .o 
```

It will then not required any external library to test generated code is valid. 
