### PR TITLE
Fix #59: Do not apply general access specifier for type with bind(c)

### DIFF
--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -2709,13 +2709,16 @@ end_declaration()
             if (ID_MAY_HAVE_ACCECIBILITY(ip) && !isAlreadyMarked(ip) 
                 && !TYPE_IS_INTRINSIC(tp)) 
             {
-                if (current_module_state == M_PUBLIC) {
-                    TYPE_SET_PUBLIC(ip);
-                }
-                if (current_module_state == M_PRIVATE 
-                    && !(ID_TYPE(ip) && TYPE_IS_IMPORTED(ID_TYPE(ip)))) 
-                {
-                    TYPE_SET_PRIVATE(ip);
+                // Type with BIND(C) cannot have access specifier (R427 - #59)
+                if(!(ID_TYPE(ip) && TYPE_HAS_BIND(ID_TYPE(ip)))) { 
+                    if (current_module_state == M_PUBLIC) {
+                        TYPE_SET_PUBLIC(ip);
+                    }
+                    if (current_module_state == M_PRIVATE 
+                        && !(ID_TYPE(ip) && TYPE_IS_IMPORTED(ID_TYPE(ip)))) 
+                    {
+                        TYPE_SET_PRIVATE(ip);
+                    }
                 }
             }
         }

--- a/F-FrontEnd/test/testdata/issue59.f90
+++ b/F-FrontEnd/test/testdata/issue59.f90
@@ -1,0 +1,8 @@
+MODULE mod1
+  IMPLICIT NONE
+  PRIVATE
+
+  TYPE, BIND(c) :: t_rt
+    INTEGER :: i
+  END TYPE t_rt
+END MODULE mod1

--- a/F-FrontEnd/test/testdata/issue59.f90
+++ b/F-FrontEnd/test/testdata/issue59.f90
@@ -2,6 +2,8 @@ MODULE mod1
   IMPLICIT NONE
   PRIVATE
 
+  INTEGER :: pi
+
   TYPE, BIND(c) :: t_rt
     INTEGER :: i
   END TYPE t_rt


### PR DESCRIPTION
Fix #59 