### PR TITLE
Fix #123:  Do not check for FINAL subroutine in the parent type

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -4182,8 +4182,10 @@ check_no_abstract_type_bound_procedure(const TYPE_DESC stp)
     for (tp = stp; tp != NULL; tp = TYPE_PARENT(tp)?TYPE_PARENT_TYPE(tp):NULL) {
         if (TYPE_IS_ABSTRACT(tp)) {
             FOREACH_TYPE_BOUND_PROCEDURE(mem, tp) {
-                if (ID_CLASS(mem) == CL_TYPE_BOUND_PROC && TBP_IS_DEFERRED(mem)) {
-                    p = find_struct_member_allow_private(stp, ID_SYM(mem), TRUE);
+                if (ID_CLASS(mem) == CL_TYPE_BOUND_PROC && TBP_IS_DEFERRED(mem)) 
+                {
+                    p = find_struct_member_allow_private(stp, 
+                        ID_SYM(mem), TRUE, TRUE);
                     if (TBP_IS_DEFERRED(p)) {
                         error("%s is not implemented", SYM_NAME(ID_SYM(mem)));
                     }

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -3577,7 +3577,8 @@ compile_type_bound_procedure_call(expv memberRef, expr args) {
         ID bind;
         ID bindto;
         FOREACH_ID(bind, TYPE_BOUND_GENERIC_TYPE_GENERICS(ftp)) {
-            bindto = find_struct_member_allow_private(stp, ID_SYM(bind), TRUE);
+            bindto = 
+                find_struct_member_allow_private(stp, ID_SYM(bind), TRUE, TRUE);
             if (TYPE_REF(ID_TYPE(bindto)) &&
                 function_type_is_appliable(TYPE_REF(ID_TYPE(bindto)), a, TRUE))
             {

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -4147,7 +4147,8 @@ check_type_bound_procedures()
              * If the parent type exists, check override.
              */
             if (parent) {
-                ID parent_tbp = find_struct_member_allow_private(tp, ID_SYM(tbp), TRUE);
+                ID parent_tbp = find_struct_member_allow_private(tp, 
+                    ID_SYM(tbp), TRUE, TRUE);
                 if (ID_CLASS(tbp) != CL_TYPE_BOUND_PROC) {
                     /* never reached */
                     error_at_id(tbp, "should not override member");
@@ -4254,19 +4255,21 @@ check_final_subroutines()
             continue;
         }
 
-        if ((final = find_struct_member(tp, sym)) != NULL) {
+        if ((final = find_struct_member_allow_private(tp, sym, FALSE, FALSE)) 
+            != NULL) 
+        {
             ID fin, fin1, fin2;
 
             FOREACH_ID(binding, TBP_BINDING(final)) {
                 if ((fin = find_ident(ID_SYM(binding))) == NULL) {
-                    error("FINAL subroutine %s does not exist",
-                          SYM_NAME(ID_SYM(binding)));
+                    error("FINAL subroutine %s does not exist for derived-type %s",
+                          SYM_NAME(ID_SYM(binding)), ID_NAME(TYPE_TAGNAME(tp)));
                     return;
                 }
                 /* DIRTY CODE, use type attribute for type-bound procedure as a flag */
                 if (TBP_BINDING_ATTRS(fin) & TYPE_BOUND_PROCEDURE_IS_FINAL) {
-                    error("FINAL subroutine %s used duplicately",
-                          SYM_NAME(ID_SYM(fin)));
+                    error("FINAL subroutine %s used duplicately in derived-type %s",
+                          SYM_NAME(ID_SYM(fin)), ID_NAME(TYPE_TAGNAME(tp)));
                     return;
                 }
                 if (!check_final_subroutine_is_valid(fin, tp)) {
@@ -7364,7 +7367,8 @@ compile_CALL_member_procedure_statement(expr x)
         ID bindto;
         tp = NULL;
         FOREACH_ID(bind, TBP_BINDING(mem)) {
-            bindto = find_struct_member_allow_private(stp, ID_SYM(bind), TRUE);
+            bindto = 
+                find_struct_member_allow_private(stp, ID_SYM(bind), TRUE, TRUE);
             if (bindto && function_type_is_appliable(ID_TYPE(bindto), a, TRUE)) 
             {
                 tp = ID_TYPE(bindto);

--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -679,11 +679,12 @@ current_struct()
 ID
 find_struct_member(TYPE_DESC struct_td, SYMBOL sym)
 {
-    return find_struct_member_allow_private(struct_td, sym, FALSE);
+    return find_struct_member_allow_private(struct_td, sym, FALSE, TRUE);
 }
 
 ID
-find_struct_member_allow_private(TYPE_DESC struct_td, SYMBOL sym, int allow_private_member)
+find_struct_member_allow_private(TYPE_DESC struct_td, SYMBOL sym, 
+    int allow_private_member, int allow_parent)
 {
     ID member = NULL;
 
@@ -720,13 +721,16 @@ find_struct_member_allow_private(TYPE_DESC struct_td, SYMBOL sym, int allow_priv
         }
     }
 
-    if (TYPE_PARENT(struct_td)) {
+    if (TYPE_PARENT(struct_td) && allow_parent) {
         ID parent = TYPE_PARENT(struct_td);
-        if (ID_SYM(parent) != NULL && (strcmp(ID_NAME(parent), SYM_NAME(sym)) == 0)) {
+        if (ID_SYM(parent) != NULL 
+            && (strcmp(ID_NAME(parent), SYM_NAME(sym)) == 0)) 
+        {
             return TYPE_PARENT(struct_td);
         }
         if (member == NULL) {
-            return find_struct_member_allow_private(ID_TYPE(parent), sym, allow_private_member);
+            return find_struct_member_allow_private(ID_TYPE(parent), sym, 
+                allow_private_member, TRUE);
         }
     }
 

--- a/F-FrontEnd/src/F-front.h
+++ b/F-FrontEnd/src/F-front.h
@@ -698,7 +698,7 @@ extern ID       find_ident_outer_scope _ANSI_ARGS_((SYMBOL s));
 extern ID       find_ident_parent _ANSI_ARGS_((SYMBOL s));
 extern ID       find_ident_sibling _ANSI_ARGS_((SYMBOL s));
 extern ID       find_struct_member _ANSI_ARGS_((TYPE_DESC struct_td, SYMBOL sym));
-extern ID       find_struct_member_allow_private _ANSI_ARGS_((TYPE_DESC struct_td, SYMBOL sym, int allow_private));
+extern ID       find_struct_member_allow_private _ANSI_ARGS_((TYPE_DESC struct_td, SYMBOL sym, int allow_private, int allow_parent));
 extern int      type_is_parent_type _ANSI_ARGS_((TYPE_DESC parent, TYPE_DESC child));
 extern int      type_is_unlimited_class _ANSI_ARGS_((TYPE_DESC tp));
 extern int      type_is_class_of _ANSI_ARGS_((TYPE_DESC class, TYPE_DESC derived_type));

--- a/F-FrontEnd/test/testdata/_issue123.f90
+++ b/F-FrontEnd/test/testdata/_issue123.f90
@@ -1,0 +1,27 @@
+module fckit_shared_ptr_module
+implicit none
+private
+
+public fckit_shared_ptr
+public fckit_shared_ptr__final_auto
+
+type :: fckit_shared_ptr
+  logical, private :: return_value = .false.
+
+contains
+  procedure, public :: final => fckit_shared_ptr__final
+
+  final :: fckit_shared_ptr__final_auto
+end type
+contains
+
+subroutine fckit_shared_ptr__final_auto(this)
+  type(fckit_shared_ptr), intent(inout) :: this
+  call this%final()
+end subroutine
+
+subroutine fckit_shared_ptr__final(this)
+  class(fckit_shared_ptr), intent(inout) :: this
+end subroutine
+
+end module

--- a/F-FrontEnd/test/testdata/issue123.f90
+++ b/F-FrontEnd/test/testdata/issue123.f90
@@ -1,0 +1,11 @@
+module fckit_shared_object_module
+use fckit_shared_ptr_module, only : fckit_shared_ptr
+implicit none
+private
+
+public :: fckit_shared_object
+
+type, extends(fckit_shared_ptr) :: fckit_shared_object
+end type
+
+end module


### PR DESCRIPTION
Fix #123
Do not check for FINAL subroutine in the parent type as this is not the right scope to check for this. 