### PR TITLE
Add more data map type: from, tofrom, alloc, release, delete

### DIFF
--- a/C-FrontEnd/src/c-omp-pragma.c
+++ b/C-FrontEnd/src/c-omp-pragma.c
@@ -63,12 +63,11 @@ static int parse_OMP_parallel_for_SIMD_pragma(void);
 #define OMP_PG_LIST(pg,args) _omp_pg_list(pg,args)
 
 #define OMP_DATA_MAP_TO      0
-#define OMP_DATA_MAP_LINK    1
-#define OMP_DATA_MAP_ALLOC   2
-#define OMP_DATA_MAP_FROM    3
-#define OMP_DATA_MAP_TOFROM  4
-#define OMP_DATA_MAP_RELEASE 5
-#define OMP_DATA_MAP_DELETE  6
+#define OMP_DATA_MAP_FROM    1
+#define OMP_DATA_MAP_TOFROM  2
+#define OMP_DATA_MAP_ALLOC   3
+#define OMP_DATA_MAP_RELEASE 4
+#define OMP_DATA_MAP_DELETE  5
 #define OMP_CLAUSE_DEVICE    0
 #define OMP_CLAUSE_SHADOW    1
 

--- a/C-FrontEnd/src/c-omp-pragma.c
+++ b/C-FrontEnd/src/c-omp-pragma.c
@@ -695,6 +695,15 @@ static CExpr* parse_array_list()
     if(PG_IS_IDENT("to")){
       args = exprListAdd(args, pg_parse_expr());
     }
+    else if(PG_IS_IDENT("from")){
+      args = exprListAdd(args, pg_parse_expr());
+    }
+    else if(PG_IS_IDENT("tofrom")){
+      args = exprListAdd(args, pg_parse_expr());
+    }
+    else if(PG_IS_IDENT("alloc")){
+      args = exprListAdd(args, pg_parse_expr());
+    }
     else if(PG_IS_IDENT("link"))
       goto not_implemented;
     else

--- a/C-FrontEnd/src/c-omp-pragma.c
+++ b/C-FrontEnd/src/c-omp-pragma.c
@@ -713,8 +713,6 @@ static CExpr* parse_array_list()
     else if(PG_IS_IDENT("delete")){
       args = exprListAdd(args, pg_parse_expr());
     }
-    else if(PG_IS_IDENT("link"))
-      goto not_implemented;
     else
       goto err;
   }
@@ -745,10 +743,6 @@ static CExpr* parse_array_list()
   
  err:
   addError(NULL,"OMP: syntax error in OpenMP pragma clause");
-  return NULL;
-
- not_implemented:
-  addError(NULL,"OMP: Not implement yet");
   return NULL;
 }
 

--- a/C-FrontEnd/src/c-omp-pragma.c
+++ b/C-FrontEnd/src/c-omp-pragma.c
@@ -704,6 +704,12 @@ static CExpr* parse_array_list()
     else if(PG_IS_IDENT("alloc")){
       args = exprListAdd(args, pg_parse_expr());
     }
+    else if(PG_IS_IDENT("release")){
+      args = exprListAdd(args, pg_parse_expr());
+    }
+    else if(PG_IS_IDENT("delete")){
+      args = exprListAdd(args, pg_parse_expr());
+    }
     else if(PG_IS_IDENT("link"))
       goto not_implemented;
     else

--- a/C-FrontEnd/src/c-omp-pragma.c
+++ b/C-FrontEnd/src/c-omp-pragma.c
@@ -65,6 +65,10 @@ static int parse_OMP_parallel_for_SIMD_pragma(void);
 #define OMP_DATA_MAP_TO    0
 #define OMP_DATA_MAP_LINK  1
 #define OMP_DATA_MAP_ALLOC 2
+#define OMP_DATA_MAP_FROM    3
+#define OMP_DATA_MAP_TOFROM  4
+#define OMP_DATA_MAP_RELEASE 5
+#define OMP_DATA_MAP_DELETE  6
 #define OMP_CLAUSE_DEVICE  0
 #define OMP_CLAUSE_SHADOW  1
 

--- a/C-FrontEnd/src/c-omp-pragma.c
+++ b/C-FrontEnd/src/c-omp-pragma.c
@@ -62,15 +62,15 @@ static int parse_OMP_parallel_for_SIMD_pragma(void);
 
 #define OMP_PG_LIST(pg,args) _omp_pg_list(pg,args)
 
-#define OMP_DATA_MAP_TO    0
-#define OMP_DATA_MAP_LINK  1
-#define OMP_DATA_MAP_ALLOC 2
+#define OMP_DATA_MAP_TO      0
+#define OMP_DATA_MAP_LINK    1
+#define OMP_DATA_MAP_ALLOC   2
 #define OMP_DATA_MAP_FROM    3
 #define OMP_DATA_MAP_TOFROM  4
 #define OMP_DATA_MAP_RELEASE 5
 #define OMP_DATA_MAP_DELETE  6
-#define OMP_CLAUSE_DEVICE  0
-#define OMP_CLAUSE_SHADOW  1
+#define OMP_CLAUSE_DEVICE    0
+#define OMP_CLAUSE_SHADOW    1
 
 static CExpr* _omp_pg_list(int omp_code,CExpr* args)
 {


### PR DESCRIPTION
In the current implementation, only "to" is allowed to use as map-type in OpenMP target data.
In OMP 5.0, from, tofrom, alloc, release and delete are also defined as map-type.
In this PR, the Front_end will accept above map-types.
