### PR TITLE
[self merge] Fix depend clause to (partially) follow omp5.0

### DIFF
--- a/C-FrontEnd/src/c-omp-pragma.c
+++ b/C-FrontEnd/src/c-omp-pragma.c
@@ -768,6 +768,12 @@ static CExpr* parse_depend_expr()
   }
 
   // todo: implement depend-modifier introduced in OpenMP 5.0
+  if (PG_IS_IDENT("iterator")) {
+    addError(NULL, "depend-modifier in depend clause is not implemented yet");
+    return NULL;
+  } else {
+    args = exprListAdd(args, NULL);
+  }
 
   // in, out, inout is introduced in OpenMP 4.0
   // mutexinoutset, depobj is introduced in OpenMP 5.0

--- a/C-FrontEnd/src/c-omp-pragma.c
+++ b/C-FrontEnd/src/c-omp-pragma.c
@@ -763,6 +763,12 @@ static CExpr* parse_depend_expr()
     addError(NULL, "OpenMP: empty name list in OpenMP directive clause");
     return NULL;
   }
+
+  // todo: implement depend-modifier introduced in OpenMP 5.0
+
+  // in, out, inout is introduced in OpenMP 4.0
+  // mutexinoutset, depobj is introduced in OpenMP 5.0
+  
   else{
     if(PG_IS_IDENT("in")){
       args = exprListAdd(args, pg_parse_expr());

--- a/C-FrontEnd/src/c-omp-pragma.c
+++ b/C-FrontEnd/src/c-omp-pragma.c
@@ -771,25 +771,24 @@ static CExpr* parse_depend_expr()
 
   // in, out, inout is introduced in OpenMP 4.0
   // mutexinoutset, depobj is introduced in OpenMP 5.0
-  else{
-    if(PG_IS_IDENT("in")){
-      args = exprListAdd(args, pg_parse_expr());
-    }
-    else if(PG_IS_IDENT("out")){
-      args = exprListAdd(args, pg_parse_expr());
-    }
-    else if(PG_IS_IDENT("inout")){
-      args = exprListAdd(args, pg_parse_expr());
-    }
-    else if(PG_IS_IDENT("mutexinoutset")){
-      args = exprListAdd(args, pg_parse_expr());
-    }
-    else if(PG_IS_IDENT("depobj")){
-      args = exprListAdd(args, pg_parse_expr());
-    }
-    else {
-      goto err;
-    }
+  if(PG_IS_IDENT("in")){
+    args = exprListAdd(args, pg_parse_expr());
+
+  }
+  else if(PG_IS_IDENT("out")){
+    args = exprListAdd(args, pg_parse_expr());
+  }
+  else if(PG_IS_IDENT("inout")){
+    args = exprListAdd(args, pg_parse_expr());
+  }
+  else if(PG_IS_IDENT("mutexinoutset")){
+    args = exprListAdd(args, pg_parse_expr());
+  }
+  else if(PG_IS_IDENT("depobj")){
+    args = exprListAdd(args, pg_parse_expr());
+  }
+  else {
+    goto err;
   }
 
 

--- a/C-FrontEnd/src/c-omp-xcodeml.c
+++ b/C-FrontEnd/src/c-omp-xcodeml.c
@@ -102,9 +102,7 @@ outx_OMP_Clause(FILE *fp, int indent, CExprOfList* clause)
       </list> 
     */
 
-
     namelist = (CExprOfList *)arg;
-    
     if (EXPR_L_SIZE(namelist) == 0) {
       break;
     }
@@ -114,7 +112,6 @@ outx_OMP_Clause(FILE *fp, int indent, CExprOfList* clause)
     // dependence-type
     outxPrint(fp,indent1,"<String>%s</String>\n",
               ((CExprOfSymbol *)EXPR_L_DATA(EXPR_L_AT(namelist, 0)))->e_symName);
-    
     // locator list
     out_OMP_name_list(fp, indent1, (CExprOfList *)EXPR_L_DATA(EXPR_L_AT(namelist, 1)));
     break;

--- a/C-FrontEnd/src/c-omp-xcodeml.c
+++ b/C-FrontEnd/src/c-omp-xcodeml.c
@@ -1,3 +1,4 @@
+/* -*- Mode: C; c-basic-offset:2 ; indent-tabs-mode:nil ; -*- */
 #include <stdlib.h>
 #include <stdarg.h> 
 #include <wchar.h>

--- a/C-FrontEnd/src/c-omp-xcodeml.c
+++ b/C-FrontEnd/src/c-omp-xcodeml.c
@@ -222,6 +222,7 @@ char *ompClauseName(int c)
   case OMP_TARGET_SHADOW:         return "TARGET_SHADOW";
   case OMP_TARGET_LAYOUT:         return "TARGET_LAYOUT";
   case OMP_TARGET_DATA_MAP:       return "TARGET_DATA_MAP";
+  case OMP_DEPEND:                return "DEPEND";
   default:                        return "???OMP???";
   }
 }

--- a/C-FrontEnd/src/c-omp-xcodeml.c
+++ b/C-FrontEnd/src/c-omp-xcodeml.c
@@ -88,11 +88,42 @@ outx_OMP_Clause(FILE *fp, int indent, CExprOfList* clause)
       outxPrint(fp,indent1,"</list>\n");
       break;
 
+  case OMP_DEPEND:
+    /*
+      <String>DEPEND</String>
+      <list>
+          <list>...</list> // depend-modifier
+          <String>in</String>
+          <list> // locator-list
+            <Var>i</Var>
+            <PointerRef>...</PointerRef>
+          </list>
+        </list> // end of locator-list
+      </list> 
+    */
+
+
+    namelist = (CExprOfList *)arg;
+    
+    if (EXPR_L_SIZE(namelist) == 0) {
+      break;
+    }
+
+    // depend-modifier
+    outxPrint(fp,indent1,"<list></list>\n"); 
+    // dependence-type
+    outxPrint(fp,indent1,"<String>%s</String>\n",
+              ((CExprOfSymbol *)EXPR_L_DATA(EXPR_L_AT(namelist, 0)))->e_symName);
+    
+    // locator list
+    out_OMP_name_list(fp, indent1, (CExprOfList *)EXPR_L_DATA(EXPR_L_AT(namelist, 1)));
+    break;
+	  
   case OMP_DATA_DEFAULT:
-      outxPrint(fp,indent1+1,"<string>%s</string>\n",
+      outxPrint(fp,indent1+1,"<String>%s</String>\n",
 		ompDataDefaultName(((CExprOfList *)arg)->e_aux));
       break;
-      
+
   default:
     namelist = (CExprOfList *)arg;
     if(EXPR_L_SIZE(namelist) != 0)

--- a/C-FrontEnd/src/c-omp-xcodeml.c
+++ b/C-FrontEnd/src/c-omp-xcodeml.c
@@ -90,10 +90,10 @@ outx_OMP_Clause(FILE *fp, int indent, CExprOfList* clause)
 
   case OMP_DEPEND:
     /*
-      <String>DEPEND</String>
+      <string>DEPEND</string>
       <list>
           <list>...</list> // depend-modifier
-          <String>in</String>
+          <string>in</string>
           <list> // locator-list
             <Var>i</Var>
             <PointerRef>...</PointerRef>
@@ -110,14 +110,14 @@ outx_OMP_Clause(FILE *fp, int indent, CExprOfList* clause)
     // depend-modifier
     outxPrint(fp,indent1,"<list></list>\n"); 
     // dependence-type
-    outxPrint(fp,indent1,"<String>%s</String>\n",
+    outxPrint(fp,indent1,"<string>%s</string>\n",
               ((CExprOfSymbol *)EXPR_L_DATA(EXPR_L_AT(namelist, 0)))->e_symName);
     // locator list
     out_OMP_name_list(fp, indent1, (CExprOfList *)EXPR_L_DATA(EXPR_L_AT(namelist, 1)));
     break;
 	  
   case OMP_DATA_DEFAULT:
-      outxPrint(fp,indent1+1,"<String>%s</String>\n",
+      outxPrint(fp,indent1+1,"<string>%s</string>\n",
 		ompDataDefaultName(((CExprOfList *)arg)->e_aux));
       break;
 

--- a/C-FrontEnd/src/c-omp-xcodeml.c
+++ b/C-FrontEnd/src/c-omp-xcodeml.c
@@ -92,7 +92,7 @@ outx_OMP_Clause(FILE *fp, int indent, CExprOfList* clause)
     /*
       <string>DEPEND</string>
       <list>
-          <list>...</list> // depend-modifier
+          <list>...</list> // depend-modifier, tentative expression
           <string>in</string>
           <list> // locator-list
             <Var>i</Var>
@@ -107,13 +107,13 @@ outx_OMP_Clause(FILE *fp, int indent, CExprOfList* clause)
       break;
     }
 
-    // depend-modifier
+    // for depend-modifier, currently it is not implemented
     outxPrint(fp,indent1,"<list></list>\n"); 
-    // dependence-type
+    // for dependence-type
     outxPrint(fp,indent1,"<string>%s</string>\n",
-              ((CExprOfSymbol *)EXPR_L_DATA(EXPR_L_AT(namelist, 0)))->e_symName);
-    // locator list
-    out_OMP_name_list(fp, indent1, (CExprOfList *)EXPR_L_DATA(EXPR_L_AT(namelist, 1)));
+              ((CExprOfSymbol *)EXPR_L_DATA(EXPR_L_AT(namelist, 1)))->e_symName);
+    // for locator list
+    out_OMP_name_list(fp, indent1, (CExprOfList *)EXPR_L_DATA(EXPR_L_AT(namelist, 2)));
     break;
 	  
   case OMP_DATA_DEFAULT:

--- a/C-FrontEnd/src/c-omp-xcodeml.c
+++ b/C-FrontEnd/src/c-omp-xcodeml.c
@@ -96,7 +96,10 @@ outx_OMP_Clause(FILE *fp, int indent, CExprOfList* clause)
           <string>in</string>
           <list> // locator-list
             <Var>i</Var>
-            <PointerRef>...</PointerRef>
+            <list>
+              <Var>a</Var>
+              <Var type="int">i</Var>
+            <list>
           </list>
         </list> // end of locator-list
       </list> 


### PR DESCRIPTION
# TL;DR;
This PR will fix https://github.com/omni-compiler/xcodeml-tools/issues/156 and partially support v2 style depend clause introduced in OpenMP 5.0, which includes depend-modifier.
In this implementation, it just creates room for the depend modifier to avoid future fix of backend, but not completely analyzed.

# Changes
In the current implementation, only below style is allowed. Only one locator is allowed to use in single depend clause, though specification allows multiple locators in the single depend clause. 
```
... depend(in:a) ...
```
With this PR, the following style is allowed to use, which follows OpenMP specification.
```
...depend(in:a, b, c)...
```


# Concerns

This PR could affect the backend analysis.
As I checked, the backend code in the master branch does not use depend clause.

