### PR TITLE
building: use YACC detected by the configure script

### DIFF
--- a/C-FrontEnd/src/Makefile.in
+++ b/C-FrontEnd/src/Makefile.in
@@ -8,6 +8,7 @@ INSTALL = @INSTALL@
 BINDIR  = @OMNI_HOME@/bin
 PERL5   = @PERL5@
 LEX     = @LEX@
+YACC    = @YACC@
 
 OBJECTS = c-parser.o c-lexer.o c-expr.o c-token.o c-exprcode.o c-dump.o c-comp.o c-reduce.o \
 	  c-xcodeml.o c-const.o c-gcctype.o c-option.o c-type.o c-convert.o \

--- a/F-FrontEnd/src/Makefile.in
+++ b/F-FrontEnd/src/Makefile.in
@@ -9,6 +9,7 @@ MKDIR_P = @MKDIR_P@
 INSTALL = @INSTALL@
 BINDIR  = @OMNI_HOME@/bin
 AWK     = @AWK@
+YACC    = @YACC@
 XMODDIR = @OMNI_HOME@/fincludes
 INTRMOD = fincludes/iso_fortran_env.xmod fincludes/iso_c_binding.xmod
 


### PR DESCRIPTION
The configure script sets `YACC` to `bison -y`. However, the makefiles still use `yacc`, which might not even be available on the system.