### PR TITLE
Refactored XCodeML output

### DIFF
--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -599,12 +599,9 @@ void declare_procedure(enum name_class cls, expr name, TYPE_DESC type,
                 /*
                  * Copy the type of the current procedure.
                  */
-                tp = new_type_desc();
-                *tp = *type;
+                tp = clone_type_shallow(type);
                 TYPE_ATTR_FLAGS(tp) = 0;
-                FUNCTION_TYPE_RETURN_TYPE(tp) = new_type_desc();
-                *FUNCTION_TYPE_RETURN_TYPE(tp) =
-                    *FUNCTION_TYPE_RETURN_TYPE(type);
+                FUNCTION_TYPE_RETURN_TYPE(tp) = clone_type_shallow(FUNCTION_TYPE_RETURN_TYPE(type));
             }
             declare_id_type(id, tp);
 
@@ -829,14 +826,6 @@ static void declare_dummy_args(expr l, enum name_class cls)
             }
         }
     }
-}
-
-TYPE_DESC
-copy_type_shallow(TYPE_DESC tp)
-{
-    TYPE_DESC ret = new_type_desc();
-    *ret = *tp;
-    return ret;
 }
 
 static void copy_parent_type(ID id)
@@ -5250,7 +5239,7 @@ static TYPE_DESC type_apply_type_parameter0(TYPE_DESC tp, ID type_params)
     } else if (TYPE_KIND(tp)) {
         v = expv_apply_type_parameter(TYPE_KIND(tp), type_params);
         if (v != TYPE_KIND(tp)) {
-            tp = copy_type_shallow(tp);
+            tp = clone_type_shallow(tp);
             TYPE_KIND(tp) = v;
             while (TYPE_REF(tp) && TYPE_KIND(TYPE_REF(tp))) {
                 TYPE_REF(tp) = TYPE_REF(TYPE_REF(tp));
@@ -5260,7 +5249,7 @@ static TYPE_DESC type_apply_type_parameter0(TYPE_DESC tp, ID type_params)
     } else if (TYPE_LENG(tp)) {
         v = expv_apply_type_parameter(TYPE_LENG(tp), type_params);
         if (v != TYPE_LENG(tp)) {
-            tp = copy_type_shallow(tp);
+            tp = clone_type_shallow(tp);
             TYPE_LENG(tp) = v;
             while (TYPE_REF(tp) && TYPE_KIND(TYPE_REF(tp))) {
                 TYPE_REF(tp) = TYPE_REF(TYPE_REF(tp));
@@ -5270,7 +5259,7 @@ static TYPE_DESC type_apply_type_parameter0(TYPE_DESC tp, ID type_params)
     } else if (TYPE_REF(tp)) {
         tq = type_apply_type_parameter0(TYPE_REF(tp), type_params);
         if (tq != TYPE_REF(tp)) {
-            tp = copy_type_shallow(tp);
+            tp = clone_type_shallow(tp);
             TYPE_REF(tp) = tq;
         }
     }
@@ -5323,7 +5312,7 @@ type_apply_type_parameter(TYPE_DESC tp, expv type_param_values)
 
     type_param_values = compiled_type_param_values;
 
-    tq = copy_type_shallow(tp);
+    tq = clone_type_shallow(tp);
 
     if (TYPE_PARENT(tq)) {
         /*

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -915,8 +915,7 @@ expv compile_expression(expr x)
                     TYPE_SET_NOT_FIXED(tp);
                 } else if (IS_ARRAY_TYPE(tp)) {
                     TYPE_DESC tq;
-                    TYPE_DESC new_tp = new_type_desc();
-                    *new_tp = *bottom_type(tp);
+                    TYPE_DESC new_tp = clone_type_shallow(bottom_type(tp));
                     tq = tp;
                     while (IS_ARRAY_TYPE(tq)) {
                         if (!IS_ARRAY_TYPE(TYPE_REF(tq)))
@@ -926,8 +925,7 @@ expv compile_expression(expr x)
                     TYPE_REF(tq) = new_tp;
                     TYPE_SET_NOT_FIXED(new_tp);
                 } else {
-                    TYPE_DESC new_tp = new_type_desc();
-                    *new_tp = *tp;
+                    TYPE_DESC new_tp = clone_type_shallow(tp);
                     tp = new_tp;
                     TYPE_SET_NOT_FIXED(tp);
                 }

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -2668,8 +2668,7 @@ static void end_declaration()
             if (ep != NULL && EXT_PROC_TYPE(ep) != NULL) {
                 /* Copy type to avoid modifying TYPE_ATTR_FLAGS */
                 if (TYPE_IS_EXTERNAL(ip)) {
-                    tp = new_type_desc();
-                    *tp = *EXT_PROC_TYPE(ep);
+                    tp = clone_type_shallow(EXT_PROC_TYPE(ep));
                 } else {
                     tp = EXT_PROC_TYPE(ep);
                 }
@@ -5435,12 +5434,8 @@ static int type_is_replica(const TYPE_DESC tp)
  */
 static TYPE_DESC shallow_copy_type_for_module_id(TYPE_DESC original)
 {
-    TYPE_DESC new_tp;
-
-    new_tp = new_type_desc();
+    TYPE_DESC new_tp = clone_type_shallow(original);
     assert(new_tp != NULL);
-
-    *new_tp = *original;
 
     /* PUBLIC/PRIVATE attribute may be given by the module user */
     TYPE_UNSET_PUBLIC(new_tp);
@@ -8140,8 +8135,7 @@ accept:
                     int extattrs = TYPE_EXTATTR_FLAGS(vPteTyp);
 
                     *vPteTyp = *ftp;
-                    tp = new_type_desc();
-                    *tp = *FUNCTION_TYPE_RETURN_TYPE(vPteTyp);
+                    tp = clone_type_shallow(FUNCTION_TYPE_RETURN_TYPE(vPteTyp));
                     FUNCTION_TYPE_RETURN_TYPE(vPteTyp) = tp;
                     TYPE_ATTR_FLAGS(vPteTyp) =
                         attrs & !(TYPE_ATTR_PUBLIC | TYPE_ATTR_PRIVATE);
@@ -9463,8 +9457,7 @@ static expv compile_forall_header(expr x)
                 } else if (!IS_INT(ID_TYPE(id))) {
                     error("%s is not integer", SYM_NAME(sym));
                 }
-                tp = new_type_desc();
-                *tp = *ID_TYPE(id);
+                tp = clone_type_shallow(ID_TYPE(id));
                 id = declare_ident(sym, CL_VAR);
             } else {
                 id = declare_ident(sym, CL_VAR);

--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -2467,8 +2467,7 @@ copy_type_partially(TYPE_DESC tp, int doCopyAttr)
 {
     TYPE_DESC ret = NULL;
     if (tp != NULL) {
-        ret = new_type_desc();
-        *ret = *tp;
+        ret = clone_type_shallow(tp);
         if (doCopyAttr == FALSE) {
             TYPE_ATTR_FLAGS(ret) = 0;
             TYPE_EXTATTR_FLAGS(ret) = 0;
@@ -2477,5 +2476,12 @@ copy_type_partially(TYPE_DESC tp, int doCopyAttr)
             TYPE_REF(ret) = copy_type_partially(TYPE_REF(tp), doCopyAttr);
         }
     }
+    return ret;
+}
+
+TYPE_DESC clone_type_shallow(TYPE_DESC tp)
+{
+    TYPE_DESC ret = new_type_desc();
+    *ret = *tp;
     return ret;
 }

--- a/F-FrontEnd/src/F-datatype.h
+++ b/F-FrontEnd/src/F-datatype.h
@@ -13,6 +13,7 @@
 
 #include "C-expr.h"
 #include <stdint.h>
+#include <stddef.h>
 
 /* f77 data types */
 typedef enum datatype {
@@ -516,11 +517,11 @@ extern TYPE_DESC basic_type_desc[];
 #define IS_STRUCT_TYPE(tp) ((tp) != NULL && TYPE_BASIC_TYPE(tp) == TYPE_STRUCT)
 #define IS_ARRAY_TYPE(tp) ((tp) != NULL && TYPE_BASIC_TYPE(tp) == TYPE_ARRAY)
 #define IS_ELEMENT_TYPE(tp) ((tp) != NULL && (tp)->ref == NULL)
-#define IS_FUNCTION_TYPE(tp)                                                   \
-    ((tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_FUNCTION))
-#define IS_SUBR(tp) ((tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_SUBR))
+static inline bool IS_FUNCTION_TYPE(TYPE_DESC tp)
+{ return (tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_FUNCTION); }
+static inline bool IS_SUBR(TYPE_DESC tp) { return (tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_SUBR); }
 #define IS_VOID(tp) ((tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_VOID))
-#define IS_PROCEDURE_TYPE(tp) (IS_FUNCTION_TYPE(tp) || IS_SUBR(tp))
+static inline bool IS_PROCEDURE_TYPE(TYPE_DESC tp) { return IS_FUNCTION_TYPE(tp) || IS_SUBR(tp); }
 #define IS_PROCEDURE_POINTER(tp)                                               \
     ((tp) != NULL && IS_PROCEDURE_TYPE(tp) && TYPE_REF(tp) != NULL)
 #define IS_GENERIC_PROCEDURE_TYPE(tp)                                          \
@@ -674,5 +675,7 @@ extern TYPE_DESC basic_type_desc[];
 #define FUNCTION_TYPE_IS_INTERFACE(tp) ((tp)->proc_info.is_interface == TRUE)
 #define FUNCTION_TYPE_SET_INTERFACE(tp) ((tp)->proc_info.is_interface = TRUE)
 #define FUNCTION_TYPE_UNSET_INTERFACE(tp) ((tp)->proc_info.is_interface = FALSE)
+
+TYPE_DESC clone_type_shallow(TYPE_DESC tp);
 
 #endif /* _F_DATATYPE_H_ */

--- a/F-FrontEnd/src/F-front-context.c
+++ b/F-FrontEnd/src/F-front-context.c
@@ -27,6 +27,7 @@ void init_ffront_context(ffront_context* ctx)
     ctx->num_errors = 0;
     ctx->current_module_name = NULL;
     ctx->current_line = NULL;
+    init_out_xcodeml_context(&ctx->out_xcodeml_ctx);
 }
 
 void free_ffront_context(ffront_context* ctx)
@@ -36,6 +37,7 @@ void free_ffront_context(ffront_context* ctx)
     release_str_stream(&ctx->src_output);
     release_str_stream(&ctx->diag_output);
     release_str_stream(&ctx->debug_output);
+    free_out_xcodeml_context(&ctx->out_xcodeml_ctx);
 }
 
 THREAD_LOCAL ffront_context* ctx;
@@ -43,4 +45,5 @@ THREAD_LOCAL ffront_context* ctx;
 void set_ffront_context(ffront_context* in_ctx)
 {
     ctx = in_ctx;
+    set_out_xcodeml_context(&ctx->out_xcodeml_ctx);
 }

--- a/F-FrontEnd/src/F-front-context.h
+++ b/F-FrontEnd/src/F-front-context.h
@@ -36,6 +36,7 @@ typedef struct {
     bool cdir_enabled;
     bool pgi_enabled;
     bool module_cache_enabled;
+    bool add_timestamp_enabled;
 } ffront_params;
 
 struct symbol;
@@ -127,5 +128,6 @@ static inline bool ocl_enabled() { return ctx->params->ocl_enabled; }
 static inline bool cdir_enabled() { return ctx->params->cdir_enabled; }
 static inline bool pgi_enabled() { return ctx->params->pgi_enabled; }
 static inline bool module_cache_enabled() { return ctx->params->module_cache_enabled; }
+static inline bool add_timestamp_enabled() { return ctx->params->add_timestamp_enabled; }
 
 #endif //_F_FRONT_CONTEXT_H_

--- a/F-FrontEnd/src/F-front-context.h
+++ b/F-FrontEnd/src/F-front-context.h
@@ -1,6 +1,7 @@
 #ifndef _F_FRONT_CONTEXT_H_
 #define _F_FRONT_CONTEXT_H_
 
+#include "F-output-xcodeml-context.h"
 #include "F-datatype.h"
 #include "bool.h"
 #include "utils.h"
@@ -55,6 +56,7 @@ typedef struct {
     str_stream debug_output;
     SYMBOL current_module_name;
     lineno_info* current_line;
+    out_xcodeml_context out_xcodeml_ctx;
 } ffront_context;
 
 extern THREAD_LOCAL ffront_context* ctx;

--- a/F-FrontEnd/src/F-front.h
+++ b/F-FrontEnd/src/F-front.h
@@ -33,10 +33,6 @@
 #define TRUE 1
 #define FALSE 0
 
-#ifdef SIMPLE_TYPE
-extern int Addr2Uint(void *x);
-#define ADDRX_PRINT_FMT "%d"
-#else /* SIMPLE_TYPE */
 #define Addr2Uint(X) ((uintptr_t)(X))
 
 #if __WORDSIZE == 64
@@ -44,7 +40,6 @@ extern int Addr2Uint(void *x);
 #else
 #define ADDRX_PRINT_FMT "%x"
 #endif
-#endif /* SIMPLE_TYPE */
 
 /*
  * Safe for the case if iter(p) (i.e. ID_NEXT(ip), EXT_ID_NEXT(ep)) is

--- a/F-FrontEnd/src/F-input-xmod.c
+++ b/F-FrontEnd/src/F-input-xmod.c
@@ -1265,8 +1265,7 @@ static int input_indexRange(xmlTextReaderPtr reader, HashTable *ht,
         return FALSE;
 
     bottom = tp;
-    base = new_type_desc();
-    *base = *bottom;
+    base = clone_type_shallow(bottom);
     TYPE_BASIC_TYPE(bottom) = TYPE_ARRAY;
     TYPE_REF(bottom) = base;
     TYPE_N_DIM(bottom) = TYPE_N_DIM(base) + 1;
@@ -1664,7 +1663,7 @@ static int input_FbasicType(xmlTextReaderPtr reader, HashTable *ht)
     TYPE_ENTRY baseTep;
     TYPE_ENTRY refTep;
     char *typeId = NULL;
-    char *ref;
+    char *ref = NULL;
     int isEmpty;
 
     if (!xmlMatchNode(reader, XML_READER_TYPE_ELEMENT, "FbasicType"))

--- a/F-FrontEnd/src/F-intrinsic.c
+++ b/F-FrontEnd/src/F-intrinsic.c
@@ -356,12 +356,10 @@ expv compile_intrinsic_call0(ID id, expv args, int ignoreTypeMismatch)
         }
 
         if (IS_VOID(tp)) {
-            TYPE_DESC ret = new_type_desc();
-            *ret = *tp;
+            TYPE_DESC ret = clone_type_shallow(tp);
             tp = intrinsic_subroutine_type();
         } else {
-            TYPE_DESC ret = new_type_desc();
-            *ret = *tp;
+            TYPE_DESC ret = clone_type_shallow(tp);
             tp = intrinsic_function_type(ret);
         }
 

--- a/F-FrontEnd/src/F-output-xcodeml-context.h
+++ b/F-FrontEnd/src/F-output-xcodeml-context.h
@@ -17,6 +17,9 @@ typedef struct type_ext_id {
 static const int type_desc_set = 33;
 KHASH_SET_INIT_INT64(type_desc_set);
 
+static const int type_to_idx_map = 34;
+KHASH_MAP_INIT_INT64(type_to_idx_map, uint64_t);
+
 struct s_out_xcodeml_context {
 	char s_timestamp[CEXPR_OPTVAL_CHARLEN];
     bool is_emitting_for_submodule;
@@ -32,6 +35,20 @@ struct s_out_xcodeml_context {
     FILE *print_fp;
     bool is_outputed_module;
     bool is_emitting_module;
+    const char* mod_name;
+    khash_t(type_to_idx_map) * t_to_idx;
+    uint64_t type_int_counter;
+    uint64_t type_char_counter;
+    uint64_t type_logical_counter;
+    uint64_t type_real_counter;
+    uint64_t type_complex_counter;
+    uint64_t type_func_counter;
+    uint64_t type_arr_counter;
+    uint64_t type_struct_counter;
+    uint64_t type_gnumeric_counter;
+    uint64_t type_generic_counter;
+    uint64_t type_namelist_counter;
+    uint64_t type_enum_counter;
 };
 
 typedef struct s_out_xcodeml_context out_xcodeml_context;

--- a/F-FrontEnd/src/F-output-xcodeml-context.h
+++ b/F-FrontEnd/src/F-output-xcodeml-context.h
@@ -1,0 +1,45 @@
+#ifndef _F_OUTPUT_XCODEML_CONTEXT_H_
+#define _F_OUTPUT_XCODEML_CONTEXT_H_
+
+#include "F-datatype.h"
+#include "F-ident.h"
+#include "utils.h"
+#include "external/klib/khash.h"
+
+#define CURRENT_FUNCTION_STACK_MAX_SIZE 100
+#define CEXPR_OPTVAL_CHARLEN 128
+
+typedef struct type_ext_id {
+    EXT_ID ep;
+    struct type_ext_id *next;
+} * TYPE_EXT_ID;
+
+static const int type_desc_set = 33;
+KHASH_SET_INIT_INT64(type_desc_set);
+
+struct s_out_xcodeml_context {
+	char s_timestamp[CEXPR_OPTVAL_CHARLEN];
+    bool is_emitting_for_submodule;
+    bool is_inside_interface;
+    EXT_ID current_function_stack[CURRENT_FUNCTION_STACK_MAX_SIZE];
+    int current_function_top;
+    // Set containing int representation of type descriptor addresses
+    khash_t(type_desc_set) * type_set;
+    khash_t(type_desc_set) * tbp_set;
+    TYPE_DESC type_list, type_list_tail;
+    TYPE_DESC tbp_list, tbp_list_tail;
+    TYPE_EXT_ID type_ext_id_list, type_ext_id_last;
+    FILE *print_fp;
+    bool is_outputed_module;
+    bool is_emitting_module;
+};
+
+typedef struct s_out_xcodeml_context out_xcodeml_context;
+
+void init_out_xcodeml_context(out_xcodeml_context*);
+void free_out_xcodeml_context(out_xcodeml_context*);
+void set_out_xcodeml_context(out_xcodeml_context*);
+
+extern THREAD_LOCAL out_xcodeml_context* outx_ctx;
+
+#endif /* _F_OUTPUT_XCODEML_CONTEXT_H_ */

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -6762,7 +6762,7 @@ void output_XcodeML_file()
             "              compiler-info=\"%s\"\n"
             "              version=\"%s\">\n",
             s,
-            F_TARGET_LANG, getTimestamp(), F_FRONTEND_NAME, F_FRONTEND_VER);
+            F_TARGET_LANG, add_timestamp_enabled() ? getTimestamp() : "", F_FRONTEND_NAME, F_FRONTEND_VER);
         sdsfree(s);
     }
 

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -5,12 +5,10 @@
 #include "F-front.h"
 #include "F-front-context.h"
 #include "F-output-xcodeml.h"
+#include "F-output-xcodeml-context.h"
 #include "module-manager.h"
 #include <limits.h>
-#include "external/klib/khash.h"
 #include "omni_errors.h"
-
-#define CHAR_BUF_SIZE 65536
 
 #define ARRAY_LEN(a) (sizeof(a) / sizeof(a[0]))
 
@@ -32,9 +30,6 @@ int Addr2Uint(void *x)
 }
 #endif
 
-int is_emitting_for_submodule;
-int is_inside_interface = FALSE;
-
 static void outx_expv(int l, expv v);
 static void outx_functionDefinition(int l, EXT_ID ep);
 static void outx_function_as_interfaceDecl(int l, EXT_ID ep);
@@ -50,20 +45,15 @@ static int id_is_visibleVar(ID id);
 static int id_is_visibleVar_for_symbols(ID id);
 static void mark_type_desc_in_id_list(ID ids);
 
-char s_timestamp[CEXPR_OPTVAL_CHARLEN] = {0};
-char s_xmlIndent[CEXPR_OPTVAL_CHARLEN] = "  ";
-
-#define CURRENT_FUNCTION_STACK_MAX_SIZE MAX_UNIT_CTL_CONTAINS + 100
+static const char* s_XML_INDENT = "  ";
 
 static const size_t current_function_stack_max_size = CURRENT_FUNCTION_STACK_MAX_SIZE;
-EXT_ID current_function_stack[CURRENT_FUNCTION_STACK_MAX_SIZE];
-int current_function_top = 0;
 
 static inline EXT_ID GET_CRT_FUNCEP()
 {
-    if(current_function_top >= 0 && current_function_top < current_function_stack_max_size)
+    if(outx_ctx->current_function_top >= 0 && outx_ctx->current_function_top < current_function_stack_max_size)
     {
-        return current_function_stack[current_function_top];
+        return outx_ctx->current_function_stack[outx_ctx->current_function_top];
     }
     else
     {
@@ -74,9 +64,9 @@ static inline EXT_ID GET_CRT_FUNCEP()
 
 static inline void SET_CRT_FUNCEP(EXT_ID ep)
 {
-    if(current_function_top >= 0 && current_function_top < current_function_stack_max_size)
+    if(outx_ctx->current_function_top >= 0 && outx_ctx->current_function_top < current_function_stack_max_size)
     {
-        current_function_stack[current_function_top] = ep;
+    	outx_ctx->current_function_stack[outx_ctx->current_function_top] = ep;
     }
     else
     {
@@ -86,10 +76,10 @@ static inline void SET_CRT_FUNCEP(EXT_ID ep)
 
 static inline void CRT_FUNCEP_PUSH(EXT_ID ep)
 {
-    current_function_top++;
-    if(current_function_top < current_function_stack_max_size)
+    outx_ctx->current_function_top++;
+    if(outx_ctx->current_function_top < current_function_stack_max_size)
     {
-        current_function_stack[current_function_top] = (ep);
+    	outx_ctx->current_function_stack[outx_ctx->current_function_top] = (ep);
     }
     else
     {
@@ -99,17 +89,12 @@ static inline void CRT_FUNCEP_PUSH(EXT_ID ep)
 
 static inline void CRT_FUNCEP_POP()
 {
-    if(current_function_top == 0)
+    if(outx_ctx->current_function_top == 0)
     {
         fatal("current_function_stack is already empty");
     }
-    current_function_top--;
+    outx_ctx->current_function_top--;
 }
-
-typedef struct type_ext_id {
-    EXT_ID ep;
-    struct type_ext_id *next;
-} * TYPE_EXT_ID;
 
 #define FOREACH_TYPE_EXT_ID(te, headte)                                        \
     for ((te) = (headte); (te) != NULL; (te) = (te)->next)
@@ -123,38 +108,22 @@ typedef struct type_ext_id {
         (tail) = (te);                                                         \
     }
 
-// Set containing int representation of type descriptor addresses
-const int type_desc_set = 33;
-KHASH_SET_INIT_INT64(type_desc_set);
-khash_t(type_desc_set) * type_set;
-khash_t(type_desc_set) * tbp_set;
-
-static TYPE_DESC type_list, type_list_tail;
-static TYPE_DESC tbp_list, tbp_list_tail;
-static TYPE_EXT_ID type_module_proc_list, type_module_proc_last;
-static TYPE_EXT_ID type_ext_id_list, type_ext_id_last;
-static FILE *print_fp;
-static char s_charBuf[CHAR_BUF_SIZE];
-static int is_outputed_module = FALSE;
-
 #define GET_EXT_LINE(ep)                                                       \
     (EXT_LINE(ep)                                                              \
          ? EXT_LINE(ep)                                                        \
          : EXT_PROC_ID_LIST(ep) ? ID_LINE(EXT_PROC_ID_LIST(ep)) : NULL)
-
-static int is_emitting_module = FALSE;
 
 /**
  * @brief Initialize sets.
  */
 static void init_sets()
 {
-    if (type_set == NULL) {
-        type_set = kh_init(type_desc_set);
+    if (outx_ctx->type_set == NULL) {
+        outx_ctx->type_set = kh_init(type_desc_set);
     }
 
-    if (tbp_set == NULL) {
-        tbp_set = kh_init(type_desc_set);
+    if (outx_ctx->tbp_set == NULL) {
+        outx_ctx->tbp_set = kh_init(type_desc_set);
     }
 }
 
@@ -163,19 +132,19 @@ static void init_sets()
  */
 static void reset_sets()
 {
-    if (tbp_set != NULL && kh_size(tbp_set) > 0) {
-        kh_destroy(type_desc_set, tbp_set);
-        tbp_set = kh_init(type_desc_set);
+    if (outx_ctx->tbp_set != NULL && kh_size(outx_ctx->tbp_set) > 0) {
+        kh_destroy(type_desc_set, outx_ctx->tbp_set);
+        outx_ctx->tbp_set = kh_init(type_desc_set);
     }
-    if (type_set != NULL && kh_size(type_set) > 0) {
-        kh_destroy(type_desc_set, type_set);
-        type_set = kh_init(type_desc_set);
+    if (outx_ctx->type_set != NULL && kh_size(outx_ctx->type_set) > 0) {
+        kh_destroy(type_desc_set, outx_ctx->type_set);
+        outx_ctx->type_set = kh_init(type_desc_set);
     }
 }
 
-static void set_module_emission_mode(int mode) { is_emitting_module = mode; }
+static void set_module_emission_mode(bool mode) { outx_ctx->is_emitting_module = mode; }
 
-int is_emitting_xmod(void) { return is_emitting_module; }
+bool is_emitting_xmod(void) { return outx_ctx->is_emitting_module; }
 
 static const char *xtag(enum expr_code code)
 {
@@ -602,7 +571,7 @@ static void outx_indent(int l)
 {
     int i;
     for (i = 0; i < l; ++i)
-        fputs(s_xmlIndent, print_fp);
+        fputs(s_XML_INDENT, outx_ctx->print_fp);
 }
 
 static void outx_printi(int l, const char *fmt, ...)
@@ -610,25 +579,27 @@ static void outx_printi(int l, const char *fmt, ...)
     outx_indent(l);
     va_list args;
     va_start(args, fmt);
-    vfprintf(print_fp, fmt, args);
+    vfprintf(outx_ctx->print_fp, fmt, args);
     va_end(args);
 }
 
 #define outx_print(...) outx_printi(0, __VA_ARGS__)
 
-static void outx_puts(const char *s) { fputs(s, print_fp); }
+static void outx_puts(const char *s) { fputs(s, outx_ctx->print_fp); }
 
 /**
  * output any tag with format
  */
 static void outx_tag(int l, const char *tagAndFmt, ...)
 {
-    sprintf(s_charBuf, "<%s>\n", tagAndFmt);
+    sds_string s_charBuf = sdsempty();
+    s_charBuf = sdscatprintf(s_charBuf, "<%s>\n", tagAndFmt);
     outx_indent(l);
     va_list args;
     va_start(args, tagAndFmt);
-    vfprintf(print_fp, s_charBuf, args);
+    vfprintf(outx_ctx->print_fp, s_charBuf, args);
     va_end(args);
+    sdsfree(s_charBuf);
 }
 
 /**
@@ -648,70 +619,63 @@ static void xstrcat(char **p, const char *s)
     *p += len;
 }
 
-static const char *getXmlEscapedStr(const char *s)
+static void getXmlEscapedStr(const char *s, sds_string* px)
 {
-    static char x[CHAR_BUF_SIZE];
     const char *p = s;
-    char *px = x;
     char c;
-    x[0] = '\0';
+    set_sds_string(px, "");
 
     while ((c = *p++)) {
         switch (c) {
             case '<':
-                xstrcat(&px, "&lt;");
+                *px = sdscat(*px, "&lt;");
                 break;
             case '>':
-                xstrcat(&px, "&gt;");
+                *px = sdscat(*px, "&gt;");
                 break;
             case '&':
-                xstrcat(&px, "&amp;");
+                *px = sdscat(*px, "&amp;");
                 break;
             case '"':
-                xstrcat(&px, "&quot;");
+                *px = sdscat(*px, "&quot;");
                 break;
             case '\'':
-                xstrcat(&px, "&apos;");
+                *px = sdscat(*px, "&apos;");
                 break;
             /* \002 used as quote in F95-lexer.c */
             case '\002':
-                xstrcat(&px, "&quot;");
+                *px = sdscat(*px, "&quot;");
                 break;
             case '\a':
-                xstrcat(&px, "\\a");
+                *px = sdscat(*px, "\\a");
                 break; // alert
             case '\f':
-                xstrcat(&px, "\\f");
+                *px = sdscat(*px, "\\f");
                 break; // formfeed
             case '\r':
-                xstrcat(&px, "\\r");
+                *px = sdscat(*px, "\\r");
                 break; // carriage return
             case '\n':
-                xstrcat(&px, "\\n");
+                *px = sdscat(*px, "\\n");
                 break; // new line
             case '\t':
-                xstrcat(&px, "\\t");
+                *px = sdscat(*px, "\\t");
                 break; // horizontal tab
             case '\b':
-                xstrcat(&px, "\\b");
+                *px = sdscat(*px, "\\b");
                 break; // backspace
             case '\v':
-                xstrcat(&px, "\\v");
+                *px = sdscat(*px, "\\v");
                 break; // vertical tab
             default:
                 if ((c >= 0 && c <= 0x1F) || c == 0x7F) {
-                    char buf[16];
-                    sprintf(buf, "&#%x;", (unsigned int)(c & 0xFF));
-                    xstrcat(&px, buf);
+                    *px = sdscatprintf(*px, "&#%x;", (unsigned int)(c & 0xFF));
                 } else {
-                    *px++ = c;
+                    *px = sdscatlen(*px, &c, 1);
                 }
                 break;
         }
     }
-    *px = 0;
-
-    return x;
 }
 
 /**
@@ -739,8 +703,8 @@ static void outx_intAsConst(int l, omllint_t n)
  * Check the string has quote character(s) or not.
  * @param str a string.
  * @return STR_HAS_NO_QUOTE: no quote character contained.
- *	<br/> STR_HAS_DBL_QUOTE: contains at least a double quote.
- *	<br/> STR_HAS_SGL_QUOTE: contains at least a single quote.
+ *    <br/> STR_HAS_DBL_QUOTE: contains at least a double quote.
+ *    <br/> STR_HAS_SGL_QUOTE: contains at least a single quote.
  */
 static int hasStringQuote(const char *str)
 {
@@ -754,13 +718,11 @@ static int hasStringQuote(const char *str)
     }
 }
 
-static const char *getRawString(expv v)
+static void getRawString(expv v, sds_string* res)
 {
-    static char buf[CHAR_BUF_SIZE];
-
     switch (EXPV_CODE(v)) {
         case INT_CONSTANT:
-            snprintf(buf, CHAR_BUF_SIZE, OMLL_DFMT, EXPV_INT_VALUE(v));
+            *res = sdscatprintf(*res, OMLL_DFMT, EXPV_INT_VALUE(v));
             break;
         case STRING_CONSTANT: {
             if (EXPV_STR(v) != NULL) {
@@ -768,13 +730,17 @@ static const char *getRawString(expv v)
                 switch (quote) {
                     case STR_HAS_SGL_QUOTE:
                     case STR_HAS_NO_QUOTE: {
-                        snprintf(buf, CHAR_BUF_SIZE, "&quot;%s&quot;",
-                                 getXmlEscapedStr(EXPV_STR(v)));
+                        sds_string s = sdsempty();
+                        getXmlEscapedStr(EXPV_STR(v), &s);
+                        *res = sdscatprintf(*res, "&quot;%s&quot;", s);
+                        sdsfree(s);
                         break;
                     }
                     case STR_HAS_DBL_QUOTE: {
-                        snprintf(buf, CHAR_BUF_SIZE, "&#39;%s&#39;",
-                                 getXmlEscapedStr(EXPV_STR(v)));
+                        sds_string s = sdsempty();
+                        getXmlEscapedStr(EXPV_STR(v), &s);
+                        *res = sdscatprintf(*res, "&#39;%s&#39;", s);
+                        sdsfree(s);
                         break;
                     }
                     default: {
@@ -783,7 +749,7 @@ static const char *getRawString(expv v)
                     }
                 }
             } else {
-                snprintf(buf, CHAR_BUF_SIZE, "\"\"");
+                *res = sdscatprintf(*res, "\"\"");
             }
             break;
         }
@@ -792,29 +758,33 @@ static const char *getRawString(expv v)
         case F_PARAM:
         case F_FUNC:
         case F95_USER_DEFINED:
-            snprintf(buf, CHAR_BUF_SIZE, "%s",
-                     getXmlEscapedStr(SYM_NAME(EXPV_NAME(v))));
+            {
+                sds_string s = sdsempty();
+                getXmlEscapedStr(SYM_NAME(EXPV_NAME(v)), &s);
+                *res = sdscatprintf(*res, "%s", s);
+                sdsfree(s);
+            }
             break;
         case ARRAY_REF:
-            snprintf(buf, CHAR_BUF_SIZE, "%s",
-                     getXmlEscapedStr(SYM_NAME(EXPV_NAME(EXPR_ARG1(v)))));
+            {
+                sds_string s = sdsempty();
+                getXmlEscapedStr(SYM_NAME(EXPV_NAME(EXPR_ARG1(v))), &s);
+                *res = sdscatprintf(*res, "%s", s);
+                sdsfree(s);
+            }
             break;
         case F_CONCAT_EXPR: {
-            char buf1[CHAR_BUF_SIZE], buf2[CHAR_BUF_SIZE];
-            strncpy(buf1, getRawString(EXPR_ARG1(v)), CHAR_BUF_SIZE);
-            strncpy(buf2, getRawString(EXPR_ARG2(v)), CHAR_BUF_SIZE);
-            int ret = snprintf(buf, CHAR_BUF_SIZE, "%s // %s", buf1, buf2);
-            if(ret < 0)
-            {
-            	fatal("Output truncated");
-            }
+            sds_string buf1 = sdsempty(), buf2 = sdsempty();
+            getRawString(EXPR_ARG1(v), &buf1);
+            getRawString(EXPR_ARG2(v), &buf2);
+            *res = sdscatprintf(*res, "%s // %s", buf1, buf2);
+            sdsfree(buf1);
+            sdsfree(buf2);
             break;
         }
         default:
             FATAL_ERROR();
     }
-
-    return buf;
 }
 
 static void outx_true(int cond, const char *flagname)
@@ -934,12 +904,10 @@ static const char *getBasicTypeID(BASIC_DATA_TYPE t)
 /**
  * get typeID
  */
-static const char *getTypeID(TYPE_DESC tp)
+void getTypeID(TYPE_DESC tp, sds_string* res)
 {
-    static char buf[256];
-
     if (checkBasic(tp) && checkBasic(TYPE_REF(tp))) {
-        strcpy(buf, getBasicTypeID(TYPE_BASIC_TYPE(tp)));
+        *res = sdscpy(*res, getBasicTypeID(TYPE_BASIC_TYPE(tp)));
     } else {
         char pfx;
 
@@ -989,10 +957,8 @@ static const char *getTypeID(TYPE_DESC tp)
                 FATAL_ERROR();
         }
 
-        sprintf(buf, "%c" ADDRX_PRINT_FMT, pfx, Addr2Uint(tp));
+        *res = sdscatprintf(*res, "%c" ADDRX_PRINT_FMT, pfx, Addr2Uint(tp));
     }
-
-    return buf;
 }
 
 /**
@@ -1009,7 +975,10 @@ static void outx_typeAttrs(int l, TYPE_DESC tp, const char *tag, int options)
     if (TYPE_IS_NOT_FIXED(tp) && TYPE_BASIC_TYPE(tp) == TYPE_UNKNOWN) {
         outx_printi(l, "<%s type=\"%s\"", tag, "FnumericAll");
     } else {
-        outx_printi(l, "<%s type=\"%s\"", tag, getTypeID(tp));
+        sds_string type_id = sdsempty();
+        getTypeID(tp, &type_id);
+        outx_printi(l, "<%s type=\"%s\"", tag, type_id);
+        sdsfree(type_id);
     }
     if (IS_STRUCT_TYPE(tp) && tp->imported_id) {
         outx_print(" imported_id=\"%s\"", tp->imported_id);
@@ -1046,7 +1015,11 @@ static void outx_typeAttrs(int l, TYPE_DESC tp, const char *tag, int options)
         outx_true(TYPE_IS_CONTIGUOUS(tp), "is_contiguous");
 
         if (TYPE_PARENT(tp)) {
-            outx_print(" extends=\"%s\"", getTypeID(TYPE_PARENT_TYPE(tp)));
+
+            sds_string type_id = sdsempty();
+            getTypeID(TYPE_PARENT_TYPE(tp), &type_id);
+            outx_print(" extends=\"%s\"", type_id);
+            sdsfree(type_id);
         }
         outx_true(TYPE_IS_CLASS(tp), "is_class");
         outx_true(TYPE_IS_ASSUMED(tp), "is_assumed");
@@ -1087,8 +1060,10 @@ static void outx_typeAttrs(int l, TYPE_DESC tp, const char *tag, int options)
 
 static void outx_typeAttrOnly_functionType(int l, TYPE_DESC tp, const char *tag)
 {
-    const char *tid = getTypeID(tp);
-    outx_printi(l, "<%s type=\"%s\"", tag, tid);
+    sds_string type_id = sdsempty();
+    getTypeID(tp, &type_id);
+    outx_printi(l, "<%s type=\"%s\"", tag, type_id);
+    sdsfree(type_id);
 }
 
 static void outx_lineno(lineno_info *li)
@@ -1097,7 +1072,12 @@ static void outx_lineno(lineno_info *li)
         outx_print(" lineno=\"%d\"", li->ln_no);
         if (li->end_ln_no)
             outx_print(" endlineno=\"%d\"", li->end_ln_no);
-        outx_print(" file=\"%s\"", getXmlEscapedStr(FILE_NAME(li->file_id)));
+        {
+            sds_string s = sdsempty();
+            getXmlEscapedStr(FILE_NAME(li->file_id), &s);
+            outx_print(" file=\"%s\"", s);
+            sdsfree(s);
+        }
     }
 }
 
@@ -1107,21 +1087,19 @@ static void outx_lineno(lineno_info *li)
 static void outx_vtagLineno(int l, const char *tag, lineno_info *li,
                             va_list args)
 {
-    static char buf1[CHAR_BUF_SIZE], buf2[CHAR_BUF_SIZE];
-    int ret = snprintf(buf1, sizeof(buf1), "<%s", tag);
-    if(ret < 0)
-    {
-    	fatal("Output truncated");
-    }
+    sds_string buf1 = sdsempty(), buf2 = sdsempty();
+    buf1 = sdscatprintf(buf1, "<%s", tag);
     if (args != NULL) {
-        vsnprintf(buf2, sizeof(buf2), buf1, args);
+        buf2 = sdscatvprintf(buf2, buf1, args);
     } else {
-        strncpy(buf2, buf1, sizeof(buf2));
+        buf2 = sdscpy(buf2, buf1);
     }
 
     outx_indent(l);
     outx_puts(buf2);
     outx_lineno(li);
+    sdsfree(buf1);
+    sdsfree(buf2);
 }
 
 static void outx_tagOfStatement(int l, expv v)
@@ -1132,12 +1110,14 @@ static void outx_tagOfStatement(int l, expv v)
 
 static void outx_tagOfStatement1(int l, expv v, const char *attrs, ...)
 {
-    sprintf(s_charBuf, "%s%s", XTAG(v), attrs ? attrs : "");
+    sds_string s_charBuf = sdsempty();
+    s_charBuf = sdscatprintf(s_charBuf, "%s%s", XTAG(v), attrs ? attrs : "");
     va_list args;
     va_start(args, attrs);
     outx_vtagLineno(l, s_charBuf, EXPR_LINE(v), args);
     va_end(args);
     outx_puts(">\n");
+    sdsfree(s_charBuf);
 }
 
 static void outx_tagOfStatement2(int l, expv v)
@@ -1158,27 +1138,33 @@ static void outx_tagOfStatement3(int l, const char *tag, lineno_info *li)
 static void outx_tagOfStatementWithConstructName(int l, expv v, expv cv,
                                                  int hasChild)
 {
+    sds_string s_charBuf = sdsempty();
     if (cv)
-        sprintf(s_charBuf, "%s construct_name=\"%s\"", XTAG(v),
+    {
+        s_charBuf = sdscatprintf(s_charBuf, "%s construct_name=\"%s\"", XTAG(v),
                 SYM_NAME(EXPV_NAME(cv)));
+    }
     else
-        strcpy(s_charBuf, XTAG(v));
+        s_charBuf = sdscpy(s_charBuf, XTAG(v));
 
     outx_vtagLineno(l, s_charBuf, EXPR_LINE(v), NULL);
     if (hasChild)
         outx_puts(">\n");
     else
         outx_puts("/>\n");
+    sdsfree(s_charBuf);
 }
 
 static void outx_tagOfStatementNoChild(int l, expv v, const char *attrs, ...)
 {
-    sprintf(s_charBuf, "%s%s", XTAG(v), attrs ? attrs : "");
+    sds_string s_charBuf = sdsempty();
+    s_charBuf = sdscatprintf(s_charBuf, "%s%s", XTAG(v), attrs ? attrs : "");
     va_list args;
     va_start(args, attrs);
     outx_vtagLineno(l, s_charBuf, EXPR_LINE(v), args);
     va_end(args);
     outx_puts("/>\n");
+    sdsfree(s_charBuf);
 }
 
 static void outx_vtagOfDecl(int l, const char *tag, lineno_info *li,
@@ -1226,8 +1212,14 @@ static void outx_tagText(int l, const char *tag, const char *s)
     outx_printi(l, "<%s>%s</%s>\n", tag, s, tag);
 }
 
-#define outx_symbolName(l, s)                                                  \
-    outx_tagText(l, "name", getXmlEscapedStr(SYM_NAME(s)))
+static void outx_symbolName(int l, const SYMBOL s)
+{
+    sds_string str = sdsempty();
+    getXmlEscapedStr(SYM_NAME(s), &str);
+    outx_tagText(l, "name", str);
+    sdsfree(str);
+}
+
 #define outx_expvName(l, v) outx_symbolName(l, EXPV_NAME(v))
 
 /**
@@ -1264,7 +1256,10 @@ static void outx_symbolNameWithFunctionType_EXT(int l, EXT_ID ep)
 static void outx_symbolNameWithType_ID(int l, ID id)
 {
     outx_typeAttrs(l, ID_TYPE(id), "name", TOPT_TYPEONLY);
-    outx_print(">%s</name>\n", getXmlEscapedStr(SYM_NAME(ID_SYM(id))));
+    sds_string s = sdsempty();
+    getXmlEscapedStr(SYM_NAME(ID_SYM(id)), &s);
+    outx_print(">%s</name>\n", s);
+    sdsfree(s);
 }
 
 /**
@@ -1272,7 +1267,10 @@ static void outx_symbolNameWithType_ID(int l, ID id)
  */
 static void outx_linenoNameWithFconstant(int l, expv fconst)
 {
-    outx_tagText(l, "name", getRawString(fconst));
+    sds_string s = sdsempty();
+    getRawString(fconst, &s);
+    outx_tagText(l, "name", s);
+    sdsfree(s);
 }
 
 /**
@@ -1901,7 +1899,12 @@ static void outx_typedArrayConstructor(int l, expv v)
     const int l1 = l + 1;
     EXPV_TYPE(v) = EXPV_TYPE(v);
     outx_typeAttrs(l, EXPV_TYPE(v), XTAG(v), TOPT_TYPEONLY);
-    outx_print(" element_type=\"%s\">\n", getTypeID(element_tp));
+    {
+        sds_string type_id = sdsempty();
+        getTypeID(element_tp, &type_id);
+        outx_print(" element_type=\"%s\">\n", type_id);
+        sdsfree(type_id);
+    }
     outx_expv(l1, EXPR_ARG1(v));
     outx_expvClose(l, v);
 }
@@ -1984,12 +1987,16 @@ static void outx_typeGuard(int l, expv v, int is_class)
         if (EXPR_ARG1(v) == NULL) { //
             outx_print(" kind=\"CLASS_DEFAULT\">\n");
         } else {
-            outx_print(" kind=\"CLASS_IS\" type=\"%s\">\n",
-                       getTypeID(EXPV_TYPE(EXPR_ARG1(v))));
+            sds_string type_id = sdsempty();
+            getTypeID(EXPV_TYPE(EXPR_ARG1(v)), &type_id);
+            outx_print(" kind=\"CLASS_IS\" type=\"%s\">\n", type_id);
+            sdsfree(type_id);
         }
     } else { // TYPE IS
-        outx_print(" kind=\"TYPE_IS\" type=\"%s\">\n",
-                   getTypeID(EXPV_TYPE(EXPR_ARG1(v))));
+        sds_string type_id = sdsempty();
+        getTypeID(EXPV_TYPE(EXPR_ARG1(v)), &type_id);
+        outx_print(" kind=\"TYPE_IS\" type=\"%s\">\n", type_id);
+        sdsfree(type_id);
     }
 
     outx_body(l1, EXPR_ARG2(v));
@@ -2102,7 +2109,10 @@ static void outx_importStatement(int l, expv v)
         FOR_ITEMS_IN_LIST (lp, ident_list) {
             arg = LIST_ITEM(lp);
             if (EXPR_CODE(arg) == IDENT) {
-                outx_printi(l1, "<name>%s</name>\n", getRawString(arg));
+                sds_string s = sdsempty();
+                getRawString(arg, &s);
+                outx_printi(l1, "<name>%s</name>\n", s);
+                sdsfree(s);
             }
         }
     }
@@ -2169,17 +2179,21 @@ static void outx_STOPPAUSE_statement_with_expression_code(int l, expv v)
  */
 static void outx_STOPPAUSE_statement(int l, expv v)
 {
-    char buf[CHAR_BUF_SIZE];
+    sds_string buf = sdsempty();
     expv v1 = EXPR_ARG1(v);
-    buf[0] = '\0';
 
     if (v1) {
         switch (EXPV_CODE(v1)) {
             case INT_CONSTANT:
-                sprintf(buf, " code=\"" OMLL_DFMT "\"", EXPV_INT_VALUE(v1));
+            	buf = sdscatprintf(buf, " code=\"" OMLL_DFMT "\"", EXPV_INT_VALUE(v1));
                 break;
             case STRING_CONSTANT:
-                sprintf(buf, " message=\"%s\"", getXmlEscapedStr(EXPV_STR(v1)));
+                {
+                	sds_string s = sdsempty();
+                    getXmlEscapedStr(EXPV_STR(v1), &s);
+                    buf = sdscatprintf(buf, " message=\"%s\"", s);
+                    sdsfree(s);
+                }
                 break;
             default:
                 return outx_STOPPAUSE_statement_with_expression_code(l, v);
@@ -2187,6 +2201,7 @@ static void outx_STOPPAUSE_statement(int l, expv v)
     }
 
     outx_tagOfStatementNoChild(l, v, buf);
+    sdsfree(buf);
 }
 
 /**
@@ -2197,19 +2212,15 @@ static void outx_EXITCYCLE_statement(int l, expv v)
     outx_tagOfStatementWithConstructName(l, v, EXPR_ARG1(v), 0);
 }
 
-static const char *getFormatID(expv v)
+static void getFormatID(expv v, sds_string* res)
 {
-    static char buf[CHAR_BUF_SIZE];
-
     if (v && EXPV_CODE(v) == LIST)
         v = EXPR_ARG1(v);
 
     if (v == NULL)
-        strcpy(buf, "*");
+        *res = sdscpy(*res, "*");
     else
-        strcpy(buf, getRawString(v));
-
-    return buf;
+        getRawString(v, res);
 }
 
 /**
@@ -2217,8 +2228,10 @@ static const char *getFormatID(expv v)
  */
 static void outx_formatDecl(int l, expv v)
 {
-    const char *fmt = getXmlEscapedStr(EXPV_STR(EXPV_LEFT(v)));
+    sds_string fmt = sdsempty();
+    getXmlEscapedStr(EXPV_STR(EXPV_LEFT(v)), &fmt);
     outx_tagOfDeclNoChild(l, "%s format=\"%s\"", EXPR_LINE(v), XTAG(v), fmt);
+    sdsfree(fmt);
 }
 
 /**
@@ -2264,8 +2277,10 @@ static void outx_printStatement(int l, expv v)
                 FATAL_ERROR();
                 break;
         }
-
-    outx_tagOfStatement1(l, v, " format=\"%s\"", getFormatID(format));
+    sds_string formatID = sdsempty();
+    getFormatID(format, &formatID);
+    outx_tagOfStatement1(l, v, " format=\"%s\"", formatID);
+    sdsfree(formatID);
     outx_valueList(l + 1, EXPR_ARG2(v));
     outx_expvClose(l, v);
 }
@@ -2624,24 +2639,20 @@ static void outx_ALLOCDEALLOC_statement(int l, expv v)
     expv vmold = expr_list_get_n(keywords, 1);
     expv vsource = expr_list_get_n(keywords, 2);
     expv verrmsg = expr_list_get_n(keywords, 3);
-    char type_buf[128];
-    char stat_buf[128];
+    {
+        sds_string type_buf = sdsempty();
 
-    const char *tid = NULL;
 
-    if (EXPV_TYPE(v)) {
-        tid = getTypeID(EXPV_TYPE(v));
-        sprintf(type_buf, " type=\"%s\"", tid);
-    } else {
-        type_buf[0] = '\0';
+        if (EXPV_TYPE(v)) {
+            sds_string tid = sdsempty();
+            getTypeID(EXPV_TYPE(v), &tid);
+            type_buf = sdscatprintf(type_buf, " type=\"%s\"", tid);
+            sdsfree(tid);
+        }
+
+        outx_tagOfStatement1(l, v, type_buf);
+        sdsfree(type_buf);
     }
-
-#if 0
-    /* Deprecated */
-    print_allocate_keyword(stat_buf, vstat, "stat_name");
-#endif
-
-    outx_tagOfStatement1(l, v, type_buf, stat_buf);
     outx_allocList(l1, EXPR_ARG1(v));
     if (vstat) {
         outx_printi(l1, "<allocOpt kind=\"stat\">\n");
@@ -2666,21 +2677,16 @@ static void outx_ALLOCDEALLOC_statement(int l, expv v)
     outx_expvClose(l, v);
 }
 
-static const char *getKindParameter(TYPE_DESC tp)
+void getKindParameter(TYPE_DESC tp, sds_string* res)
 {
-    static char buf[256];
     expv v = TYPE_KIND(tp);
 
     if (IS_DOUBLED_TYPE(tp)) {
-        sprintf(buf, "%d", KIND_PARAM_DOUBLE);
+        *res = sdscatprintf(*res, "%d", KIND_PARAM_DOUBLE);
     } else if (v && (EXPV_CODE(v) == INT_CONSTANT || EXPV_CODE(v) == IDENT ||
                      EXPV_CODE(v) == F_VAR || EXPV_CODE(v) == FLOAT_CONSTANT)) {
-        strcpy(buf, getRawString(v));
-    } else {
-        return NULL;
+        getRawString(v, res);
     }
-
-    return buf;
 }
 
 /**
@@ -2688,51 +2694,60 @@ static const char *getKindParameter(TYPE_DESC tp)
  */
 static void outx_constants(int l, expv v)
 {
-    static char buf[CHAR_BUF_SIZE];
+    sds_string buf = sdsempty();
     const int l1 = l + 1;
-    const char *tid;
+    sds_string tid = sdsempty();
     const char *tag = XTAG(v);
     TYPE_DESC tp = EXPV_TYPE(v);
-    const char *kind;
 
     switch (EXPV_CODE(v)) {
         case INT_CONSTANT:
             if (IS_LOGICAL(EXPV_TYPE(v))) {
-                sprintf(buf, ".%s.", EXPV_INT_VALUE(v) ? "TRUE" : "FALSE");
+                buf = sdscatprintf(buf, ".%s.", EXPV_INT_VALUE(v) ? "TRUE" : "FALSE");
                 tag = "FlogicalConstant";
             } else {
                 omllint_t n = EXPV_INT_VALUE(v);
-                sprintf(buf, OMLL_DFMT, n);
+                buf = sdscatprintf(buf, OMLL_DFMT, n);
             }
             if (tp == NULL)
                 tp = type_INT;
             // tid = getBasicTypeID(TYPE_BASIC_TYPE(tp));
-            tid = getTypeID(tp);
+            getTypeID(tp, &tid);
             goto print_constant;
 
         case FLOAT_CONSTANT:
             if (EXPV_ORIGINAL_TOKEN(v))
-                strcpy(buf, EXPV_ORIGINAL_TOKEN(v));
+                buf = sdscpy(buf, EXPV_ORIGINAL_TOKEN(v));
             else
-                sprintf(buf, "%Lf", EXPV_FLOAT_VALUE(v));
+                buf = sdscatprintf(buf, "%Lf", EXPV_FLOAT_VALUE(v));
             if (tp == NULL)
                 tp = type_REAL;
             // tid = getBasicTypeID(TYPE_BASIC_TYPE(tp));
-            tid = getTypeID(tp);
+            getTypeID(tp, &tid);
             goto print_constant;
 
         case STRING_CONSTANT:
-            strcpy(buf, getXmlEscapedStr(EXPV_STR(v)));
+            {
+                sds_string s = sdsempty();
+                getXmlEscapedStr(EXPV_STR(v), &s);
+                buf = sdscpy(buf, s);
+                sdsfree(s);
+            }
             assert(tp);
-            tid = getTypeID(tp);
+            getTypeID(tp, &tid);
             goto print_constant;
 
         print_constant:
             outx_printi(l, "<%s type=\"%s\"", tag, tid);
-            if ( // EXPV_CODE(v) != STRING_CONSTANT &&
-                (kind = getKindParameter(tp)) != NULL)
-                outx_print(" kind=\"%s\"", kind);
-            outx_print(">%s</%s>\n", buf, tag);
+            {
+                sds_string kind = sdsempty();
+                getKindParameter(tp, &kind);
+                if ( // EXPV_CODE(v) != STRING_CONSTANT &&
+                    sdslen(kind) != 0)
+                    outx_print(" kind=\"%s\"", kind);
+                outx_print(">%s</%s>\n", buf, tag);
+                sdsfree(kind);
+            }
             break;
 
         case COMPLEX_CONSTANT:
@@ -2746,6 +2761,8 @@ static void outx_constants(int l, expv v)
         default:
             FATAL_ERROR();
     }
+    sdsfree(buf);
+    sdsfree(tid);
 }
 
 /**
@@ -2755,7 +2772,12 @@ static void outx_pragmaStatement(int l, expv v)
 {
     list lp = EXPV_LIST(v);
     outx_tagOfStatement2(l, v);
-    outx_puts(getXmlEscapedStr(EXPV_STR(LIST_ITEM(lp))));
+    {
+        sds_string s = sdsempty();
+        getXmlEscapedStr(EXPV_STR(LIST_ITEM(lp)), &s);
+        outx_puts(s);
+        sdsfree(s);
+    }
     outx_expvClose(0, v);
 }
 
@@ -2766,7 +2788,12 @@ static void outx_commentLine(int l, expv v)
 {
     list lp = EXPV_LIST(v);
     outx_tagOfStatement2(l, v);
-    outx_puts(getXmlEscapedStr(EXPV_STR(LIST_ITEM(lp))));
+    {
+        sds_string s = sdsempty();
+        getXmlEscapedStr(EXPV_STR(LIST_ITEM(lp)), &s);
+        outx_puts(s);
+        sdsfree(s);
+    }
     outx_expvClose(0, v);
 }
 
@@ -3663,8 +3690,18 @@ static void outx_useRename(int l, expv x)
     if (EXPR_CODE(x) == F03_OPERATOR_RENAMING) {
         outx_true(TRUE, "is_operator");
     }
-    outx_printi(0, " local_name=\"%s\"", getRawString(local));
-    outx_printi(0, " use_name=\"%s\"/>\n", getRawString(use));
+    {
+        sds_string s = sdsempty();
+        getRawString(local, &s);
+        outx_printi(0, " local_name=\"%s\"", s);
+        sdsfree(s);
+    }
+    {
+        sds_string s = sdsempty();
+        getRawString(use, &s);
+        outx_printi(0, " use_name=\"%s\"/>\n", s);
+        sdsfree(s);
+    }
 }
 
 /**
@@ -3687,7 +3724,7 @@ static void outx_useDecl(int l, expv v, int is_intrinsic)
         outx_useRename(l + 1, x);
     }
 
-    include_module_file(print_fp, EXPV_NAME(EXPR_ARG1(v)));
+    include_module_file(outx_ctx->print_fp, EXPV_NAME(EXPR_ARG1(v)));
 
     outx_expvClose(l, v);
 }
@@ -3706,9 +3743,18 @@ static void outx_useRenamable(int l, int expr_code, expv local, expv use)
     }
 
     if (local != NULL)
-        outx_printi(0, " local_name=\"%s\"", getRawString(local));
-
-    outx_printi(0, " use_name=\"%s\"/>\n", getRawString(use));
+    {
+        sds_string s = sdsempty();
+        getRawString(local, &s);
+        outx_printi(0, " local_name=\"%s\"", s);
+        sdsfree(s);
+    }
+    {
+        sds_string s = sdsempty();
+        getRawString(use, &s);
+        outx_printi(0, " use_name=\"%s\"/>\n", s);
+        sdsfree(s);
+    }
 }
 
 /**
@@ -3731,7 +3777,7 @@ static void outx_useOnlyDecl(int l, expv v, int is_intrinsic)
         outx_useRenamable(l + 1, EXPR_CODE(x), EXPR_ARG1(x), EXPR_ARG2(x));
     }
 
-    include_module_file(print_fp, EXPV_NAME(EXPR_ARG1(v)));
+    include_module_file(outx_ctx->print_fp, EXPV_NAME(EXPR_ARG1(v)));
 
     outx_expvClose(l, v);
 }
@@ -3915,7 +3961,6 @@ static void outx_FORALL_statement(int l, expv v)
     expv init = EXPR_ARG1(EXPR_ARG1(v));
     expv mask = EXPR_ARG2(EXPR_ARG1(v));
     expv body = EXPR_ARG2(v);
-    const char *tid = NULL;
 
     outx_vtagLineno(l, XTAG(v), EXPR_LINE(v), NULL);
 
@@ -3923,8 +3968,10 @@ static void outx_FORALL_statement(int l, expv v)
         outx_print(" construct_name=\"%s\"", SYM_NAME(EXPR_SYM(EXPR_ARG4(v))));
     }
     if (EXPV_TYPE(init)) {
-        tid = getTypeID(EXPV_TYPE(init));
+        sds_string tid = sdsempty();
+        getTypeID(EXPV_TYPE(init), &tid);
         outx_print(" type=\"%s\"", tid);
+        sdsfree(tid);
     }
     outx_print(">\n");
 
@@ -3990,8 +4037,10 @@ static void outx_DOCONCURRENT_statement(int l, expv v)
         outx_print(" construct_name=\"%s\"", SYM_NAME(EXPR_SYM(EXPR_ARG3(v))));
     }
     if (EXPV_TYPE(EXPR_ARG1(v))) {
-        tid = getTypeID(EXPV_TYPE(EXPR_ARG1(v)));
+        sds_string tid = sdsempty();
+        getTypeID(EXPV_TYPE(EXPR_ARG1(v)), &tid);
         outx_print(" type=\"%s\"", tid);
+        sdsfree(tid);
     }
     outx_print(">\n");
 
@@ -4642,7 +4691,7 @@ static void mark_type_desc_skip_tbp(TYPE_DESC tp, int skip_tbp)
          */
         TYPE_LINK(tp) = NULL;
         TYPE_IS_REFERENCED(tp) = TRUE;
-        TYPE_LINK_ADD_WITH_SET(tp, tbp_list, tbp_list_tail, tbp_set);
+        TYPE_LINK_ADD_WITH_SET(tp, outx_ctx->tbp_list, outx_ctx->tbp_list_tail, outx_ctx->tbp_set);
         return;
     }
 
@@ -4668,7 +4717,7 @@ static void mark_type_desc_skip_tbp(TYPE_DESC tp, int skip_tbp)
     collect_type_desc(TYPE_DIM_LOWER(tp));
     collect_type_desc(TYPE_DIM_STEP(tp));
 
-    TYPE_LINK_ADD_WITH_SET(tp, type_list, type_list_tail, type_set);
+    TYPE_LINK_ADD_WITH_SET(tp, outx_ctx->type_list, outx_ctx->type_list_tail, outx_ctx->type_set);
     TYPE_IS_REFERENCED(tp) = TRUE;
 
     if (IS_PROCEDURE_TYPE(tp)) {
@@ -4701,17 +4750,17 @@ static void mark_type_desc(TYPE_DESC tp) { mark_type_desc_skip_tbp(tp, TRUE); }
 
 /*       if (TYPE_IS_COSHAPE(tp)){ */
 
-/* 	if (TYPE_IS_COSHAPE(TYPE_REF(tp))){ */
-/* 	  check_type_desc(TYPE_REF(tp)); */
-/* 	} */
-/* 	else { */
+/*     if (TYPE_IS_COSHAPE(TYPE_REF(tp))){ */
+/*       check_type_desc(TYPE_REF(tp)); */
+/*     } */
+/*     else { */
 
-/* 	  mark_type_desc(TYPE_REF(tp)); */
-/* 	} */
+/*       mark_type_desc(TYPE_REF(tp)); */
+/*     } */
 
 /*       } */
 /*       else { */
-/* 	mark_type_desc(array_element_type(tp)); */
+/*     mark_type_desc(array_element_type(tp)); */
 /*       } */
 
 /*     } */
@@ -4777,7 +4826,7 @@ void add_type_ext_id(EXT_ID ep)
     TYPE_EXT_ID te = XMALLOC(TYPE_EXT_ID, sizeof(struct type_ext_id));
     // bzero(te, sizeof(struct type_ext_id));
     te->ep = ep;
-    FUNC_EXT_LINK_ADD(te, type_ext_id_list, type_ext_id_last);
+    FUNC_EXT_LINK_ADD(te, outx_ctx->type_ext_id_list, outx_ctx->type_ext_id_last);
 }
 
 static void mark_type_desc_id(ID id)
@@ -4828,7 +4877,7 @@ static void mark_type_desc_in_id_list(ID ids)
 static void unmark_type_table()
 {
     TYPE_DESC tp;
-    for (tp = type_list; tp != NULL; tp = TYPE_LINK(tp)) {
+    for (tp = outx_ctx->type_list; tp != NULL; tp = TYPE_LINK(tp)) {
         if (tp == NULL || TYPE_IS_REFERENCED(tp) == FALSE || IS_MODULE(tp))
             continue;
         TYPE_IS_REFERENCED(tp) = FALSE;
@@ -4837,11 +4886,8 @@ static void unmark_type_table()
 
 static void outx_kind(int l, TYPE_DESC tp)
 {
-    static expv doubledKind = NULL;
+    expv doubledKind = expv_int_term(INT_CONSTANT, type_INT, KIND_PARAM_DOUBLE);
     expv vkind;
-
-    if (doubledKind == NULL)
-        doubledKind = expv_int_term(INT_CONSTANT, type_INT, KIND_PARAM_DOUBLE);
 
     if (IS_DOUBLED_TYPE(tp))
         vkind = doubledKind;
@@ -4851,6 +4897,7 @@ static void outx_kind(int l, TYPE_DESC tp)
         return;
 
     outx_childrenWithTag(l, "kind", vkind);
+    free(doubledKind);
 }
 
 /**
@@ -4946,15 +4993,22 @@ static void outx_basicTypeNoCharNoAry(int l, TYPE_DESC tp)
     assert(rtp);
     outx_typeAttrs(l, tp, "FbasicType", 0);
     if (TYPE_TYPE_PARAM_VALUES(tp) || tp->codims) {
-        outx_print(" ref=\"%s\">\n", getTypeID(rtp));
+        sds_string tid = sdsempty();
+        getTypeID(rtp, &tid);
+        outx_print(" ref=\"%s\">\n", tid);
+        sdsfree(tid);
         if (tp->codims)
             outx_coShape(l + 1, tp);
         if (TYPE_TYPE_PARAM_VALUES(tp)) {
             outx_typeParamValues(l + 1, TYPE_TYPE_PARAM_VALUES(tp));
         }
         outx_close(l, "FbasicType");
-    } else
-        outx_print(" ref=\"%s\"/>\n", getTypeID(rtp));
+    } else {
+        sds_string tid = sdsempty();
+        getTypeID(rtp, &tid);
+        outx_print(" ref=\"%s\"/>\n", tid);
+        sdsfree(tid);
+    }
 }
 
 /**
@@ -5003,7 +5057,11 @@ static void outx_arrayType(int l, TYPE_DESC tp)
     const int l1 = l + 1;
 
     outx_typeAttrs(l, tp, "FbasicType", 0);
-    outx_print(" ref=\"%s\">\n", getTypeID(array_element_type(tp)));
+
+    sds_string tid = sdsempty();
+    getTypeID(array_element_type(tp), &tid);
+    outx_print(" ref=\"%s\">\n", tid);
+    sdsfree(tid);
 
     outx_indexRangeOfType(l1, tp);
 
@@ -5046,7 +5104,10 @@ static void outx_functionType_procedure(int l, TYPE_DESC tp)
          * the procedure variable declared like "PROCEDURE(), POINTER :: p".
          * So don't emit this attribute.
          */
-        outx_print(" ref=\"%s\"/>\n", getTypeID(TYPE_REF(tp)));
+        sds_string tid = sdsempty();
+        getTypeID(TYPE_REF(tp), &tid);
+        outx_print(" ref=\"%s\"/>\n", tid);
+        sdsfree(tid);
     } else {
         outx_print("/>\n");
     }
@@ -5063,11 +5124,13 @@ static void outx_functionType(int l, TYPE_DESC tp)
 
     } else {
         const int l1 = l + 1, l2 = l1 + 1;
-        const char *rtid = NULL;
 
-        const char *tid = getTypeID(tp);
-
-        outx_printi(l, "<FfunctionType type=\"%s\"", tid);
+        {
+            sds_string tid = sdsempty();
+            getTypeID(tp, &tid);
+            outx_printi(l, "<FfunctionType type=\"%s\"", tid);
+            sdsfree(tid);
+        }
 
         if (FUNCTION_TYPE_RESULT(tp)) {
             outx_print(" result_name=\"%s\"",
@@ -5077,13 +5140,18 @@ static void outx_functionType(int l, TYPE_DESC tp)
         /* outx_typeAttrOnly_functionTypeWithResultVar(l, ep, "FfunctionType");
          */
 
-        if (FUNCTION_TYPE_RETURN_TYPE(tp)) {
-            rtid = getTypeID(FUNCTION_TYPE_RETURN_TYPE(tp));
-        } else {
-            rtid = "Fvoid";
+        {
+            sds_string rtid = sdsempty();
+            if (FUNCTION_TYPE_RETURN_TYPE(tp)) {
+                getTypeID(FUNCTION_TYPE_RETURN_TYPE(tp), &rtid);
+            } else {
+                rtid = sdscpy(rtid, "Fvoid");
+            }
+            outx_print(" return_type=\"%s\"", rtid);
+            sdsfree(rtid);
         }
 
-        outx_print(" return_type=\"%s\"", rtid);
+
         outx_true(FUNCTION_TYPE_IS_PROGRAM(tp), "is_program");
 
         if (FUNCTION_TYPE_IS_VISIBLE_INTRINSIC(tp)) {
@@ -5097,7 +5165,7 @@ static void outx_functionType(int l, TYPE_DESC tp)
 
         outx_false(TYPE_IS_IMPURE(tp), "is_pure");
 
-        if (is_emitting_for_submodule) {
+        if (outx_ctx->is_emitting_for_submodule) {
             /*
              * "is_defined" attribute is only for SUBMODULE
              */
@@ -5159,7 +5227,12 @@ static void outx_structType(int l, TYPE_DESC tp)
                 continue;
             }
             outx_printi(l2, "<typeParam ");
-            outx_print("type=\"%s\" ", getTypeID(ID_TYPE(id)));
+            {
+                sds_string tid = sdsempty();
+                getTypeID(ID_TYPE(id), &tid);
+                outx_print("type=\"%s\" ", tid);
+                sdsfree(tid);
+            }
             if (TYPE_IS_KIND(ID_TYPE(id))) {
                 outx_print("attr=\"kind\">\n");
             } else if (TYPE_IS_LEN(ID_TYPE(id))) {
@@ -5181,7 +5254,12 @@ static void outx_structType(int l, TYPE_DESC tp)
             has_type_bound_procedure = TRUE;
             continue;
         }
-        outx_printi(l2, "<id type=\"%s\">\n", getTypeID(ID_TYPE(id)));
+        {
+            sds_string tid = sdsempty();
+            getTypeID(ID_TYPE(id), &tid);
+            outx_printi(l2, "<id type=\"%s\">\n", tid);
+            sdsfree(tid);
+        }
         outx_symbolName(l3, ID_SYM(id));
         if (VAR_INIT_VALUE(id) != NULL) {
             outx_value(l3, VAR_INIT_VALUE(id));
@@ -5232,11 +5310,17 @@ static void outx_structType(int l, TYPE_DESC tp)
                 outx_true(TYPE_IS_PRIVATE(id), "is_private");
                 outx_printi(0, ">\n");
                 if (!is_defined_io) {
-                    outx_tagText(l3, "name", getXmlEscapedStr(SYM_NAME(ID_SYM(id))));
+                    sds_string s = sdsempty();
+                    getXmlEscapedStr(SYM_NAME(ID_SYM(id)), &s);
+                    outx_tagText(l3, "name", s);
+                    sdsfree(s);
                 }
                 outx_tag(l3, "binding");
                 FOREACH_ID (binding, TBP_BINDING(id)) {
-                    outx_tagText(l4, "name", getXmlEscapedStr(SYM_NAME(ID_SYM(binding))));
+                    sds_string s = sdsempty();
+                    getXmlEscapedStr(SYM_NAME(ID_SYM(binding)), &s);
+                    outx_tagText(l4, "name", s);
+                    sdsfree(s);
                 }
                 outx_close(l3, "binding");
                 outx_close(l2, "typeBoundGenericProcedure");
@@ -5250,7 +5334,12 @@ static void outx_structType(int l, TYPE_DESC tp)
                 }
             } else {
                 outx_printi(l2, "<typeBoundProcedure");
-                outx_printi(0, " type=\"%s\"", getTypeID(ID_TYPE(id)));
+                {
+                    sds_string tid = sdsempty();
+                    getTypeID(ID_TYPE(id), &tid);
+                    outx_printi(0, " type=\"%s\"", tid);
+                    sdsfree(tid);
+                }
 
                 if (TBP_BINDING_ATTRS(id) & TYPE_BOUND_PROCEDURE_PASS)
                     outx_printi(0, " pass=\"pass\"");
@@ -5271,9 +5360,21 @@ static void outx_structType(int l, TYPE_DESC tp)
 
                 outx_printi(0, ">\n");
 
-                outx_tagText(l3, "name", getXmlEscapedStr(SYM_NAME(ID_SYM(id))));
+                {
+                    sds_string s = sdsempty();
+                    getXmlEscapedStr(SYM_NAME(ID_SYM(id)), &s);
+                    outx_tagText(l3, "name", s);
+                    sdsfree(s);
+                }
+
                 outx_tag(l3, "binding");
-                outx_tagText(l4, "name", getXmlEscapedStr(SYM_NAME(ID_SYM(TBP_BINDING(id)))));
+
+                {
+                    sds_string s = sdsempty();
+                    getXmlEscapedStr(SYM_NAME(ID_SYM(TBP_BINDING(id))), &s);
+                    outx_tagText(l4, "name", s);
+                    sdsfree(s);
+                }
                 outx_close(l3, "binding");
 
                 outx_close(l2, "typeBoundProcedure");
@@ -5373,7 +5474,7 @@ static int id_is_visibleVar(ID id)
         if (TYPE_IS_MODIFIED(tp)) {
             return TRUE;
         }
-        if ((is_outputed_module && GET_CRT_FUNCEP() == NULL) &&
+        if ((outx_ctx->is_outputed_module && GET_CRT_FUNCEP() == NULL) &&
             (TYPE_IS_PUBLIC(tp) || TYPE_IS_PRIVATE(tp))) {
             return TRUE;
         }
@@ -5534,8 +5635,10 @@ static void outx_enumDecl(int l, ID id)
     if (id == NULL)
         return;
 
-    outx_tagOfDeclNoChild(l, "%s type=\"%s\"", ID_LINE(id), "FenumDecl",
-                          getTypeID(ID_TYPE(id)));
+    sds_string tid = sdsempty();
+    getTypeID(ID_TYPE(id), &tid);
+    outx_tagOfDeclNoChild(l, "%s type=\"%s\"", ID_LINE(id), "FenumDecl", tid);
+    sdsfree(tid);
 }
 
 static int qsort_compare_id(const void *v1, const void *v2)
@@ -5647,8 +5750,8 @@ static int is_id_used_in_struct_member(ID id, TYPE_DESC sTp)
 {
     /*
      * FIXME:
-     *	Actually, it is not checked if id is used in sTp's member.
-     *	Instead, just checking line number.
+     *    Actually, it is not checked if id is used in sTp's member.
+     *    Instead, just checking line number.
      */
     ID mId;
 
@@ -5683,7 +5786,7 @@ static void emit_decl(int l, ID id)
         return;
     }
 
-    if (!is_inside_interface && GET_CRT_FUNCEP() != NULL &&
+    if (!outx_ctx->is_inside_interface && GET_CRT_FUNCEP() != NULL &&
         EXT_PROC_IS_PROCEDUREDECL(GET_CRT_FUNCEP())) {
 
         /*
@@ -6009,7 +6112,7 @@ static void outx_moduleProcedureDecl(int l, EXT_ID ep, SYMBOL parentName)
 {
     const int l1 = l + 1;
 
-    if (is_emitting_xmod() == FALSE) {
+    if (!is_emitting_xmod()) {
         if (EXT_TAG(ep) == STG_EXT && !EXT_IS_OFMODULE(ep)) {
             if (EXT_PROC_IS_MODULE_SPECIFIED(ep)) {
                 outx_tagOfDecl1(
@@ -6148,7 +6251,7 @@ static void outx_function_as_interfaceDecl(int l, EXT_ID ep)
 
     CRT_FUNCEP_PUSH(NULL);
     outx_printi(l, "<FinterfaceDecl");
-    is_inside_interface = TRUE;
+    outx_ctx->is_inside_interface = true;
 
     if (TYPE_IS_ABSTRACT(EXT_PROC_TYPE(ep)))
         outx_true(TRUE, "is_abstract");
@@ -6157,7 +6260,7 @@ static void outx_function_as_interfaceDecl(int l, EXT_ID ep)
     outx_printi(0, ">\n");
     outx_functionDecl(l + 1, ep);
     outx_close(l, "FinterfaceDecl");
-    is_inside_interface = FALSE;
+    outx_ctx->is_inside_interface = false;
     CRT_FUNCEP_POP();
 }
 
@@ -6192,7 +6295,7 @@ static void outx_interfaceDecl(int l, EXT_ID ep)
 
     CRT_FUNCEP_PUSH(NULL);
     outx_printi(l, "<FinterfaceDecl");
-    is_inside_interface = TRUE;
+    outx_ctx->is_inside_interface = true;
 
     switch (EXT_PROC_INTERFACE_CLASS(ep)) {
         case INTF_DECL:
@@ -6204,8 +6307,12 @@ static void outx_interfaceDecl(int l, EXT_ID ep)
             break;
         case INTF_OPERATOR:
         case INTF_USEROP:
-            outx_printi(0, " name=\"%s\"",
-                        getXmlEscapedStr(SYM_NAME(EXT_SYM(ep))));
+            {
+                sds_string s = sdsempty();
+                getXmlEscapedStr(SYM_NAME(EXT_SYM(ep)), &s);
+                outx_printi(0, " name=\"%s\"", s);
+                sdsfree(s);
+            }
             outx_true(TRUE, "is_operator");
             break;
         case INTF_GENERIC_WRITE_FORMATTED:
@@ -6232,7 +6339,7 @@ static void outx_interfaceDecl(int l, EXT_ID ep)
     outx_printi(0, ">\n");
     outx_moduleProcedureDecls(l + 1, extids, EXT_SYM(ep));
     outx_close(l, "FinterfaceDecl");
-    is_inside_interface = FALSE;
+    outx_ctx->is_inside_interface = false;
     CRT_FUNCEP_POP();
 }
 
@@ -6273,7 +6380,7 @@ static void outx_moduleDefinition(int l, EXT_ID ep)
 {
     const int l1 = l + 1;
 
-    is_outputed_module = TRUE;
+    outx_ctx->is_outputed_module = true;
 
     SET_CRT_FUNCEP(NULL);
 
@@ -6297,7 +6404,7 @@ static void outx_moduleDefinition(int l, EXT_ID ep)
     outx_contains(l1, ep);
     outx_close(l, "FmoduleDefinition");
 
-    is_outputed_module = FALSE;
+    outx_ctx->is_outputed_module = false;
 }
 
 /**
@@ -6323,8 +6430,8 @@ static const char *getTimestamp()
 {
     const time_t t = time(NULL);
     struct tm *ltm = localtime(&t);
-    strftime(s_timestamp, CEXPR_OPTVAL_CHARLEN, "%F %T", ltm);
-    return s_timestamp;
+    strftime(outx_ctx->s_timestamp, CEXPR_OPTVAL_CHARLEN, "%F %T", ltm);
+    return outx_ctx->s_timestamp;
 }
 
 /**
@@ -6423,7 +6530,7 @@ static void collect_types(EXT_ID extid)
     TYPE_DESC sTp;
 
     collect_types1(extid);
-    FOREACH_TYPE_EXT_ID (te, type_ext_id_list) {
+    FOREACH_TYPE_EXT_ID (te, outx_ctx->type_ext_id_list) {
         TYPE_DESC tp = EXT_PROC_TYPE(te->ep);
         if (tp && EXT_TAG(te->ep) == STG_EXT) {
             sTp = reduce_type(EXT_PROC_TYPE(te->ep));
@@ -6435,7 +6542,7 @@ static void collect_types(EXT_ID extid)
     /*
      * now mark type-bound procedures
      */
-    for (tp = tbp_list; tp != NULL; tp = tq) {
+    for (tp = outx_ctx->tbp_list; tp != NULL; tp = tq) {
         tq = TYPE_LINK(tp);
         TYPE_LINK(tp) = NULL;
         TYPE_IS_REFERENCED(tp) = FALSE;
@@ -6452,7 +6559,7 @@ static void collect_types_inner(EXT_ID extid)
     TYPE_DESC sTp;
 
     collect_types1(extid);
-    FOREACH_TYPE_EXT_ID (te, type_ext_id_list) {
+    FOREACH_TYPE_EXT_ID (te, outx_ctx->type_ext_id_list) {
         TYPE_DESC tp = EXT_PROC_TYPE(te->ep);
         if (tp && EXT_TAG(te->ep) == STG_EXT) {
             sTp = reduce_type(EXT_PROC_TYPE(te->ep));
@@ -6472,7 +6579,7 @@ static void outx_typeTable(int l)
 
     outx_tag(l, "typeTable");
 
-    for (tp = type_list; tp != NULL; tp = TYPE_LINK(tp)) {
+    for (tp = outx_ctx->type_list; tp != NULL; tp = TYPE_LINK(tp)) {
         outx_type(l1, tp);
     }
 
@@ -6545,32 +6652,35 @@ void output_XcodeML_file()
     if (module_compile_enabled())
         return; // DO NOTHING
 
-    type_list = NULL;
+    outx_ctx->type_list = NULL;
 
     init_sets();
 
-    type_module_proc_list = NULL;
-    type_module_proc_last = NULL;
-    type_ext_id_list = NULL;
-    type_ext_id_last = NULL;
-    tbp_list = NULL;
-    tbp_list_tail = NULL;
+    outx_ctx->type_ext_id_list = NULL;
+    outx_ctx->type_ext_id_last = NULL;
+    outx_ctx->tbp_list = NULL;
+    outx_ctx->tbp_list_tail = NULL;
 
     collect_types(EXTERNAL_SYMBOLS);
     SET_CRT_FUNCEP(NULL);
 
-    print_fp = src_output();
+    outx_ctx->print_fp = src_output();
     const int l = 0, l1 = l + 1;
 
-    outx_printi(
-        l,
-        "<XcodeProgram source=\"%s\"\n"
-        "              language=\"%s\"\n"
-        "              time=\"%s\"\n"
-        "              compiler-info=\"%s\"\n"
-        "              version=\"%s\">\n",
-        getXmlEscapedStr(sdslen(ctx->src_file_path) != 0  ? ctx->src_file_path : "<stdin>"),
-        F_TARGET_LANG, getTimestamp(), F_FRONTEND_NAME, F_FRONTEND_VER);
+    {
+        sds_string s = sdsempty();
+        getXmlEscapedStr(sdslen(ctx->src_file_path) != 0  ? ctx->src_file_path : "<stdin>", &s);
+        outx_printi(
+            l,
+            "<XcodeProgram source=\"%s\"\n"
+            "              language=\"%s\"\n"
+            "              time=\"%s\"\n"
+            "              compiler-info=\"%s\"\n"
+            "              version=\"%s\">\n",
+            s,
+            F_TARGET_LANG, getTimestamp(), F_FRONTEND_NAME, F_FRONTEND_VER);
+        sdsfree(s);
+    }
 
     outx_typeTable(l1);
     outx_globalSymbols(l1);
@@ -6607,8 +6717,12 @@ static void outx_id_mod(int l, ID id)
     const char *sclass = get_sclass(id);
 
     outx_print(" sclass=\"%s\"", sclass);
-    outx_print(" original_name=\"%s\"",
-               getXmlEscapedStr(SYM_NAME(id->use_assoc->original_name)));
+    {
+        sds_string s = sdsempty();
+        getXmlEscapedStr(SYM_NAME(id->use_assoc->original_name), &s);
+        outx_print(" original_name=\"%s\"", s);
+        sdsfree(s);
+    }
     outx_print(" declared_in=\"%s\"", SYM_NAME(id->use_assoc->module_name));
     if (ID_IS_AMBIGUOUS(id))
         outx_print(" is_ambiguous=\"true\"");
@@ -6784,35 +6898,33 @@ int output_module_file(struct module *mod, const char *filename)
     TYPE_DESC sTp;
     TYPE_DESC tp;
     TYPE_DESC tq;
-    int oEmitMode;
+    bool oEmitMode;
     expr modTypeList;
     list lp;
     expv v;
 
     if (module_compile_enabled()) {
-        print_fp = src_output();
+        outx_ctx->print_fp = src_output();
     } else {
-        if ((print_fp = fopen(filename, "w")) == NULL) {
+        if ((outx_ctx->print_fp = fopen(filename, "w")) == NULL) {
             fatal("couldn't open module file to write: %s", filename);
             return FALSE;
         }
     }
 
-    is_emitting_for_submodule = MODULE_IS_FOR_SUBMODULE(mod);
+    outx_ctx->is_emitting_for_submodule = MODULE_IS_FOR_SUBMODULE(mod);
 
     init_sets();
 
     oEmitMode = is_emitting_xmod();
-    set_module_emission_mode(TRUE);
+    set_module_emission_mode(true);
 
-    type_list = NULL;
+    outx_ctx->type_list = NULL;
 
-    type_module_proc_list = NULL;
-    type_module_proc_last = NULL;
-    type_ext_id_list = NULL;
-    type_ext_id_last = NULL;
-    tbp_list = NULL;
-    tbp_list_tail = NULL;
+    outx_ctx->type_ext_id_list = NULL;
+    outx_ctx->type_ext_id_last = NULL;
+    outx_ctx->tbp_list = NULL;
+    outx_ctx->tbp_list_tail = NULL;
 
     /*
      * collect types used in this module
@@ -6824,7 +6936,7 @@ int output_module_file(struct module *mod, const char *filename)
         // if id is external,  ...
         if (ep != NULL) {
             collect_types1(ep);
-            FOREACH_TYPE_EXT_ID (te, type_ext_id_list) {
+            FOREACH_TYPE_EXT_ID (te, outx_ctx->type_ext_id_list) {
                 TYPE_DESC tp = EXT_PROC_TYPE(te->ep);
                 if (tp && EXT_TAG(te->ep) == STG_EXT) {
                     sTp = reduce_type(EXT_PROC_TYPE(te->ep));
@@ -6849,7 +6961,7 @@ int output_module_file(struct module *mod, const char *filename)
     /*
      * now mark type-bound procedures
      */
-    for (tp = tbp_list; tp != NULL; tp = tq) {
+    for (tp = outx_ctx->tbp_list; tp != NULL; tp = tq) {
         tq = TYPE_LINK(tp);
         TYPE_LINK(tp) = NULL;
         TYPE_IS_REFERENCED(tp) = FALSE;
@@ -6864,10 +6976,10 @@ int output_module_file(struct module *mod, const char *filename)
     set_module_emission_mode(oEmitMode);
 
     if (!module_compile_enabled()) {
-        fclose(print_fp);
+        fclose(outx_ctx->print_fp);
     }
 
-    is_emitting_for_submodule = FALSE;
+    outx_ctx->is_emitting_for_submodule = false;
 
     return TRUE;
 }
@@ -6932,4 +7044,24 @@ void final_fixup()
             fixup_function_call(v);
         }
     }
+}
+
+void init_out_xcodeml_context(out_xcodeml_context* ctx)
+{
+    ctx->is_inside_interface = false;
+    ctx->current_function_top = 0;
+    ctx->is_outputed_module = false;
+    ctx->is_emitting_module = false;
+    memset(ctx->s_timestamp, 0, CEXPR_OPTVAL_CHARLEN);
+}
+
+void free_out_xcodeml_context(out_xcodeml_context* ctx)
+{
+}
+
+THREAD_LOCAL out_xcodeml_context* outx_ctx;
+
+void set_out_xcodeml_context(out_xcodeml_context* in_ctx)
+{
+    outx_ctx = in_ctx;
 }

--- a/F-FrontEnd/src/F-output-xcodeml.h
+++ b/F-FrontEnd/src/F-output-xcodeml.h
@@ -31,7 +31,4 @@ extern int output_module_file(struct module *, const char *);
 #define F_FRONTEND_VER "1.0"
 #define F_MODULE_VER "1.0"
 
-extern char s_timestamp[];
-extern char s_xmlIndent[];
-
 #endif /* _F_XCODEML_H_ */

--- a/F-FrontEnd/src/F95-main.c
+++ b/F-FrontEnd/src/F95-main.c
@@ -99,6 +99,7 @@ static void usage(const cli_options* opts)
         "-endlineno                output the endlineno attribute.", "",
         "internal options:", "-d                        enable debug mode.",
         "-no-module-cache          always load module from file.",
+        "-no-time                  do not add timestamp to xcodeml.",
 
         NULL};
     const char *const *p = usages;
@@ -290,7 +291,9 @@ void parse_cli_args(cli_options* opts, int argc, char *argv[])
             break;
         } else if (strcmp(argv[0], "-no-module-cache") == 0) {
             set_module_cache_enabled(opts, false);
-        } else {
+        } else if (strcmp(argv[0], "-no-time") == 0) {
+            set_add_timestamp_enabled(opts, false);
+        }  else {
             cmd_error_exit("unknown option : %s", argv[0]);
         }
         --argc;
@@ -343,6 +346,7 @@ void init_context_from_cli_opts(ffront_context* local_ctx, const cli_options* op
     params->cdir_enabled = get_cdir_enabled(opts);
     params->pgi_enabled = get_pgi_enabled(opts);
     params->module_cache_enabled = get_module_cache_enabled(opts);
+    params->add_timestamp_enabled = get_add_timestamp_enabled(opts);
     const bool force_fixed_format = get_force_fixed_format_enabled(opts);
 
     local_ctx->fixed_format_enabled = force_fixed_format;

--- a/F-FrontEnd/src/cli_options.c
+++ b/F-FrontEnd/src/cli_options.c
@@ -24,6 +24,7 @@ static const bool DEFAULT_OCL_ENABLED = false;
 static const bool DEFAULT_PGI_ENABLED = false;
 static const bool DEFAULT_CDIR_ENABLED = false;
 static const bool DEFAULT_MODULE_CACHE_ENABLED = true;
+static const bool DEFAULT_ADD_TIMESTAMP_ENABLED = true;
 static const bool DEFAULT_PRINT_HELP = false;
 static const bool DEFAULT_PRINT_OPTS = false;
 
@@ -60,6 +61,7 @@ void init_cli_options(cli_options* opts)
     opts->cdir_enabled = DEFAULT_CDIR_ENABLED;
     opts->pgi_enabled = DEFAULT_PGI_ENABLED;
     opts->module_cache_enabled = DEFAULT_MODULE_CACHE_ENABLED;
+    opts->add_timestamp_enabled = DEFAULT_ADD_TIMESTAMP_ENABLED;
     opts->print_help = DEFAULT_PRINT_HELP;
     opts->print_opts = DEFAULT_PRINT_OPTS;
 }

--- a/F-FrontEnd/src/cli_options.h
+++ b/F-FrontEnd/src/cli_options.h
@@ -39,6 +39,7 @@ typedef struct {
     bool cdir_enabled;
     bool pgi_enabled;
     bool module_cache_enabled;
+    bool add_timestamp_enabled;
     bool print_help;
     bool print_opts;
 } cli_options;
@@ -255,6 +256,12 @@ static inline void set_module_cache_enabled(cli_options *opts, bool val) {
 }
 static inline bool get_module_cache_enabled(const cli_options *opts) {
     return opts->module_cache_enabled;
+}
+static inline void set_add_timestamp_enabled(cli_options *opts, bool val) {
+    opts->add_timestamp_enabled = val;
+}
+static inline bool get_add_timestamp_enabled(const cli_options *opts) {
+    return opts->add_timestamp_enabled;
 }
 static inline void set_print_help(cli_options *opts, bool val) {
     opts->print_help = val;

--- a/F-FrontEnd/src/module-manager.c
+++ b/F-FrontEnd/src/module-manager.c
@@ -19,7 +19,7 @@ struct module_manager {
 
 static struct module *find_module(const SYMBOL module_name,
                                   const SYMBOL submodule_name,
-                                  int for_submodule)
+                                  bool for_submodule)
 {
     struct module *mp;
     assert(module_name != NULL);
@@ -271,7 +271,7 @@ int export_submodule(SYMBOL submod_name, SYMBOL mod_name, ID ids,
 
 static int import_intermediate_file(const SYMBOL name,
                                     const SYMBOL submodule_name,
-                                    struct module **pmod, int as_for_submodule)
+                                    struct module **pmod, bool as_for_submodule)
 {
     struct module *mod;
     const char *extension;
@@ -304,7 +304,7 @@ static int import_intermediate_file(const SYMBOL name,
  */
 int import_module(const SYMBOL name, struct module **pmod)
 {
-    return import_intermediate_file(name, NULL, pmod, FALSE);
+    return import_intermediate_file(name, NULL, pmod, false);
 }
 
 /**
@@ -313,7 +313,7 @@ int import_module(const SYMBOL name, struct module **pmod)
 int import_submodule(const SYMBOL module_name, const SYMBOL submodule_name,
                      struct module **pmod)
 {
-    return import_intermediate_file(module_name, submodule_name, pmod, TRUE);
+    return import_intermediate_file(module_name, submodule_name, pmod, true);
 }
 
 void include_module_file(FILE *fp, SYMBOL mod_name)
@@ -322,7 +322,7 @@ void include_module_file(FILE *fp, SYMBOL mod_name)
     FILE *mod_fp;
     int ch;
 
-    mod = find_module(mod_name, NULL, FALSE);
+    mod = find_module(mod_name, NULL, false);
     if (mod == NULL || mod->filepath == NULL)
         return;
     if ((mod_fp = fopen(mod->filepath, "r")) == NULL) {

--- a/F-FrontEnd/src/module-manager.h
+++ b/F-FrontEnd/src/module-manager.h
@@ -37,7 +37,7 @@ struct module {
     ID head;               /* public elements of this module. */
     ID last;
     int is_intrinsic;  /* TRUE if this module is an intrinsic module. */
-    int for_submodule; /* module for submodule */
+    bool for_submodule; /* module for submodule */
     char *filepath;    /* path for module file */
 };
 


### PR DESCRIPTION
- removed (non-constant) static variables from F-output-xcodeml;
- added typeid generator
  -  creates non-random typeids unique within one translation unit. 
  - for xmods, name of the module is added to the id, to retain uniqueness globally during imports;
  - values are guarantied  to be the same if F_Front is run on identical input;
- made timestamp addition to XCodeML optional;