### PR TITLE
Added in-memory processing mode to FFront JNI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ script:
 - make -j test-ffront-c
 - make -j test-ffront-cpp
 - make -j test-ffront-cpp-shared
+- make -j test-ffront-jni
 - echo "Testing in-source GNU Make build"
 - cd ${OMNI_SRC}
 - ./configure && make && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ script:
 - make install
 - make -j test-ffront-c
 - make -j test-ffront-cpp
-- make -j test-ffront-cpp-shared
 - make -j test-ffront-jni
 - echo "Testing in-source GNU Make build"
 - cd ${OMNI_SRC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
 - make install
 - make -j test-ffront-c
 - make -j test-ffront-cpp
+- make -j test-ffront-cpp-shared
 - echo "Testing in-source GNU Make build"
 - cd ${OMNI_SRC}
 - ./configure && make && make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ if(${Python3_FOUND})
      COMMAND ${CMAKE_COMMAND} -E remove_directory ${TEST_FFRONT_JNI_WORKING_DIR}
      COMMAND ${CMAKE_COMMAND} -E make_directory ${TEST_FFRONT_JNI_WORKING_DIR}
      COMMAND ${Python3_EXECUTABLE} ${TESTS_RUNNER} -f ${INT_OMNI_FFRONT_JNI} -b ${INT_OMNI_FBACK} -x ${INT_OMNI_HOME_FINCLUDES}
-               -w ${TEST_FFRONT_JNI_WORKING_DIR} -j ${MAX_PARALLEL_TESTS}
+               -w ${TEST_FFRONT_JNI_WORKING_DIR} -j ${MAX_PARALLEL_TESTS} --in-memory
      COMMENT "Testing ffront JNI bindings")
     add_dependencies(test-ffront-jni build-jni-install ffront-jni-driver)
   endif() #JNI_FOUND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
 endif()
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 IF(CMAKE_BUILD_TYPE MATCHES Debug)
   message("Debug build")
   set(BUILD_TYPE "Debug")
@@ -89,7 +91,7 @@ set(OMNI_HOME "${CMAKE_INSTALL_PREFIX}")
 add_custom_target(create_int_install_dirs ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory ${INT_OMNI_HOME}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${INT_OMNI_HOME_BIN}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${INT_OMNI_HOME_SHARE})
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${INT_OMNI_HOME_SHARE}
 
 install(
     DIRECTORY ${INT_OMNI_HOME}/
@@ -121,16 +123,16 @@ add_subdirectory(Driver/bin)
 
 add_custom_target(build-c-install DEPENDS ffront om-f-back fback-driver std-lib-xmods)
 add_custom_target(build-cpp-install DEPENDS ffront-cpp om-f-back fback-driver std-lib-xmods)
+add_custom_target(build-cpp-shared-install DEPENDS ffront-cpp-shared om-f-back fback-driver std-lib-xmods)
 
 find_package(Python3 3.6 COMPONENTS Interpreter)
 
 if(${Python3_FOUND})
-  set(TEST_FFRONT_C_WORKING_DIR ${CMAKE_BINARY_DIR}/tests/ffront-c)
-  set(TEST_FFRONT_CPP_WORKING_DIR ${CMAKE_BINARY_DIR}/tests/ffront-cpp)
   set(TESTS_RUNNER ${CMAKE_SOURCE_DIR}/F-FrontEnd/src/tests-runner.py)
 
   ProcessorCount(MAX_PARALLEL_TESTS)
 
+  set(TEST_FFRONT_C_WORKING_DIR ${CMAKE_BINARY_DIR}/tests/ffront-c)
   add_custom_target(test-ffront-c)
   add_custom_command(
    TARGET test-ffront-c
@@ -141,6 +143,7 @@ if(${Python3_FOUND})
    COMMENT "Testing ffront C executable")
   add_dependencies(test-ffront-c build-c-install)
 
+  set(TEST_FFRONT_CPP_WORKING_DIR ${CMAKE_BINARY_DIR}/tests/ffront-cpp)
   add_custom_target(test-ffront-cpp)
   add_custom_command(
    TARGET test-ffront-cpp
@@ -150,6 +153,19 @@ if(${Python3_FOUND})
              -w ${TEST_FFRONT_CPP_WORKING_DIR} -j ${MAX_PARALLEL_TESTS}
    COMMENT "Testing ffront CPP executable")
   add_dependencies(test-ffront-cpp build-cpp-install)
+
+  set(TEST_FFRONT_SHARED_CPP_WORKING_DIR ${CMAKE_BINARY_DIR}/tests/ffront-shared-cpp)
+  set(INT_OMNI_FFRONT_SHARED_CPP ${INT_OMNI_HOME_SHARE}/libffront-cpp.so)
+  add_custom_target(test-ffront-cpp-shared)
+  add_custom_command(
+   TARGET test-ffront-cpp-shared
+   COMMAND ${CMAKE_COMMAND} -E remove_directory ${TEST_FFRONT_SHARED_CPP_WORKING_DIR}
+   COMMAND ${CMAKE_COMMAND} -E make_directory ${TEST_FFRONT_SHARED_CPP_WORKING_DIR}
+   COMMAND ${Python3_EXECUTABLE} ${TESTS_RUNNER} -f ${INT_OMNI_FFRONT_SHARED_CPP} -b ${INT_OMNI_FBACK} -x ${INT_OMNI_HOME_FINCLUDES}
+             -w ${TEST_FFRONT_SHARED_CPP_WORKING_DIR} -j ${MAX_PARALLEL_TESTS}
+   COMMENT "Testing ffront shared CPP library as executable")
+  add_dependencies(test-ffront-cpp-shared build-cpp-shared-install)
+
 else()
   message(WARNING "Python not found, testing targets will be unavailable")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
     message(FATAL_ERROR "Java ${Java_VERSION_STRING} is not supported")
   endif()
 endif()
+find_package(JNI)
 
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
@@ -85,6 +86,7 @@ set(INT_OMNI_FFRONT_CPP "${INT_OMNI_HOME_BIN}/ffront-cpp")
 set(INT_OMNI_FBACK "${INT_OMNI_HOME_BIN}/F_Back")
 set(INT_OMNI_HOME_FINCLUDES "${INT_OMNI_HOME}/fincludes")
 set(INT_OMNI_HOME_SHARE "${INT_OMNI_HOME}/share")
+set(INT_OMNI_HOME_SHARE_3RDPARTY "${INT_OMNI_HOME}/share/3rdparty")
 
 set(OMNI_HOME "${CMAKE_INSTALL_PREFIX}")
 
@@ -92,6 +94,7 @@ add_custom_target(create_int_install_dirs ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory ${INT_OMNI_HOME}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${INT_OMNI_HOME_BIN}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${INT_OMNI_HOME_SHARE}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${INT_OMNI_HOME_SHARE_3RDPARTY})
 
 install(
     DIRECTORY ${INT_OMNI_HOME}/
@@ -113,6 +116,7 @@ if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" STREQU
 endif()
 
 add_subdirectory(F-FrontEnd/src)
+add_subdirectory(F-FrontEnd-jni/src)
 
 set(CMAKE_JAVA_COMPILE_FLAGS -encoding utf8 -Xlint:deprecation,unchecked)
 
@@ -124,6 +128,10 @@ add_subdirectory(Driver/bin)
 add_custom_target(build-c-install DEPENDS ffront om-f-back fback-driver std-lib-xmods)
 add_custom_target(build-cpp-install DEPENDS ffront-cpp om-f-back fback-driver std-lib-xmods)
 add_custom_target(build-cpp-shared-install DEPENDS ffront-cpp-shared om-f-back fback-driver std-lib-xmods)
+
+if(${JNI_FOUND})
+add_custom_target(build-jni-install DEPENDS ffront-jni om-f-back fback-driver std-lib-xmods)
+endif()
 
 find_package(Python3 3.6 COMPONENTS Interpreter)
 
@@ -166,7 +174,19 @@ if(${Python3_FOUND})
    COMMENT "Testing ffront shared CPP library as executable")
   add_dependencies(test-ffront-cpp-shared build-cpp-shared-install)
 
+  if(${JNI_FOUND})
+    set(TEST_FFRONT_JNI_WORKING_DIR ${CMAKE_BINARY_DIR}/tests/ffront-jni)
+    set(INT_OMNI_FFRONT_JNI ${INT_OMNI_HOME_BIN}/ffront-jni)
+    add_custom_target(test-ffront-jni)
+    add_custom_command(
+     TARGET test-ffront-jni
+     COMMAND ${CMAKE_COMMAND} -E remove_directory ${TEST_FFRONT_JNI_WORKING_DIR}
+     COMMAND ${CMAKE_COMMAND} -E make_directory ${TEST_FFRONT_JNI_WORKING_DIR}
+     COMMAND ${Python3_EXECUTABLE} ${TESTS_RUNNER} -f ${INT_OMNI_FFRONT_JNI} -b ${INT_OMNI_FBACK} -x ${INT_OMNI_HOME_FINCLUDES}
+               -w ${TEST_FFRONT_JNI_WORKING_DIR} -j ${MAX_PARALLEL_TESTS}
+     COMMENT "Testing ffront JNI bindings")
+    add_dependencies(test-ffront-jni build-jni-install ffront-jni-driver)
+  endif() #JNI_FOUND
 else()
   message(WARNING "Python not found, testing targets will be unavailable")
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,6 @@ add_subdirectory(Driver/bin)
 
 add_custom_target(build-c-install DEPENDS ffront om-f-back fback-driver std-lib-xmods)
 add_custom_target(build-cpp-install DEPENDS ffront-cpp om-f-back fback-driver std-lib-xmods)
-add_custom_target(build-cpp-shared-install DEPENDS ffront-cpp-shared om-f-back fback-driver std-lib-xmods)
 
 if(${JNI_FOUND})
 add_custom_target(build-jni-install DEPENDS ffront-jni om-f-back fback-driver std-lib-xmods)
@@ -161,18 +160,6 @@ if(${Python3_FOUND})
              -w ${TEST_FFRONT_CPP_WORKING_DIR} -j ${MAX_PARALLEL_TESTS}
    COMMENT "Testing ffront CPP executable")
   add_dependencies(test-ffront-cpp build-cpp-install)
-
-  set(TEST_FFRONT_SHARED_CPP_WORKING_DIR ${CMAKE_BINARY_DIR}/tests/ffront-shared-cpp)
-  set(INT_OMNI_FFRONT_SHARED_CPP ${INT_OMNI_HOME_SHARE}/libffront-cpp.so)
-  add_custom_target(test-ffront-cpp-shared)
-  add_custom_command(
-   TARGET test-ffront-cpp-shared
-   COMMAND ${CMAKE_COMMAND} -E remove_directory ${TEST_FFRONT_SHARED_CPP_WORKING_DIR}
-   COMMAND ${CMAKE_COMMAND} -E make_directory ${TEST_FFRONT_SHARED_CPP_WORKING_DIR}
-   COMMAND ${Python3_EXECUTABLE} ${TESTS_RUNNER} -f ${INT_OMNI_FFRONT_SHARED_CPP} -b ${INT_OMNI_FBACK} -x ${INT_OMNI_HOME_FINCLUDES}
-             -w ${TEST_FFRONT_SHARED_CPP_WORKING_DIR} -j ${MAX_PARALLEL_TESTS}
-   COMMENT "Testing ffront shared CPP library as executable")
-  add_dependencies(test-ffront-cpp-shared build-cpp-shared-install)
 
   if(${JNI_FOUND})
     set(TEST_FFRONT_JNI_WORKING_DIR ${CMAKE_BINARY_DIR}/tests/ffront-jni)

--- a/Driver/bin/CMakeLists.txt
+++ b/Driver/bin/CMakeLists.txt
@@ -14,6 +14,7 @@ add_custom_command(OUTPUT ${INT_F_BACK_DRIVER}
                    VERBATIM)
 
 add_custom_target(fback-driver ALL DEPENDS ${INT_F_BACK_DRIVER})
+add_dependencies(fback-driver om-f-back)
 
 set(C_BACK_DRIVER ${CMAKE_CURRENT_BINARY_DIR}/C_Back)
 set(INT_C_BACK_DRIVER ${INT_OMNI_HOME_BIN}/C_Back)
@@ -29,3 +30,19 @@ add_custom_command(OUTPUT ${INT_C_BACK_DRIVER}
                    VERBATIM)
 
 add_custom_target(cback-driver ALL DEPENDS ${INT_C_BACK_DRIVER})
+
+set(FFRONT_JNI_DRIVER ${CMAKE_CURRENT_BINARY_DIR}/ffront-jni)
+set(INT_FFRONT_JNI_DRIVER ${INT_OMNI_HOME_BIN}/ffront-jni)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ffront-jni.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/tmp/ffront-jni @ONLY)
+file(COPY ${CMAKE_CURRENT_BINARY_DIR}/tmp/ffront-jni
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+  FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
+
+add_custom_command(OUTPUT ${INT_FFRONT_JNI_DRIVER}
+                   COMMAND ${CMAKE_COMMAND}  -E copy ${FFRONT_JNI_DRIVER} ${INT_FFRONT_JNI_DRIVER}
+                   MAIN_DEPENDENCY ${FFRONT_JNI_DRIVER}
+                   DEPENDS create_int_install_dirs
+                   VERBATIM)
+
+add_custom_target(ffront-jni-driver ALL DEPENDS ${INT_FFRONT_JNI_DRIVER})
+add_dependencies(ffront-jni-driver ffront-jni)

--- a/Driver/bin/CMakeLists.txt
+++ b/Driver/bin/CMakeLists.txt
@@ -44,5 +44,5 @@ add_custom_command(OUTPUT ${INT_FFRONT_JNI_DRIVER}
                    DEPENDS create_int_install_dirs
                    VERBATIM)
 
-add_custom_target(ffront-jni-driver ALL DEPENDS ${INT_FFRONT_JNI_DRIVER})
+add_custom_target(ffront-jni-driver DEPENDS ${INT_FFRONT_JNI_DRIVER})
 add_dependencies(ffront-jni-driver ffront-jni)

--- a/Driver/bin/ffront-jni.cmake.in
+++ b/Driver/bin/ffront-jni.cmake.in
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+THIS_DIR=$(dirname "$(readlink -f "$0")")
+OMNI_HOME="${THIS_DIR}/.."
+OMNI_SHARE="${OMNI_HOME}/share"
+OMNI_SHARE_3RDPARTY="${OMNI_HOME}/share/3rdparty"
+FFRONT_JAR="${OMNI_SHARE}/ffront.jar"
+ARGPARSE_JAR="${OMNI_SHARE_3RDPARTY}/argparse4j-0.9.0.jar"
+
+if [ -z ${OMNI_JAVA+x} ]; then
+OMNI_JAVA=@Java_JAVA_EXECUTABLE@
+fi
+
+OMNI_JAVA_OPT="-cp ${FFRONT_JAR}:${ARGPARSE_JAR} -Djava.library.path=${OMNI_SHARE} xcodeml.f.util.FxCompiler"
+exec ${OMNI_JAVA} ${OMNI_JAVA_OPT} $*

--- a/F-FrontEnd-jni/src/CMakeLists.txt
+++ b/F-FrontEnd-jni/src/CMakeLists.txt
@@ -47,7 +47,7 @@ set_target_properties(ffront-jni
                       OUTPUT_NAME ffront-jni)
 target_include_directories(ffront-jni PRIVATE ${FFRONT_INC_DIRS} ${JAVA_C_HEADERS_DIR} ${JNI_INCLUDE_DIRS})
 target_compile_definitions(ffront-jni PRIVATE ${FFRONT_DEFINES})
-target_link_libraries(ffront-jni ffront-cpp-shared ${JNI_LIBRARIES} ${LIBXML2_LIBRARY})
+target_link_libraries(ffront-jni ffront-cpp-shared ${JNI_LIBRARIES} ${LIBXML2_LIBRARY} "-Wl,-rpath,'$ORIGIN/.'")
 
 else()
   message(WARNING "JNI not found, java bindings will be unavailable")

--- a/F-FrontEnd-jni/src/CMakeLists.txt
+++ b/F-FrontEnd-jni/src/CMakeLists.txt
@@ -1,0 +1,54 @@
+if(${JNI_FOUND})
+
+file(GLOB_RECURSE ffront_java_SRC "${CMAKE_CURRENT_SOURCE_DIR}/java/*.java")
+
+set(ARGPARSE4J_VERSION "0.9.0")
+set(ARGPARSE4J_FILENAME "argparse4j-${ARGPARSE4J_VERSION}.jar")
+set(ARGPARSE4J_JAR "${INT_OMNI_HOME_SHARE_3RDPARTY}/${ARGPARSE4J_FILENAME}")
+set(ARGPARSE4J_URL "https://github.com/argparse4j/argparse4j/releases/download/argparse4j-${ARGPARSE4J_VERSION}/${ARGPARSE4J_FILENAME}")
+
+include(ExternalProject)
+
+ExternalProject_Add(
+    argparse4j
+    URL "${ARGPARSE4J_URL}"
+    DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/3rdparty"
+    DOWNLOAD_NO_EXTRACT OFF
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/3rdparty/${ARGPARSE4J_FILENAME}" ${ARGPARSE4J_JAR}
+    BUILD_BYPRODUCTS ${ARGPARSE4J_JAR}
+    INSTALL_COMMAND ""
+)
+
+add_custom_command(OUTPUT ${ARGPARSE4J_JAR}
+                   COMMAND COMMAND ${CMAKE_COMMAND} -E copy_if_different  "${CMAKE_CURRENT_BINARY_DIR}/3rdparty/${ARGPARSE4J_FILENAME}" ${ARGPARSE4J_JAR}
+                   DEPENDS argparse4j
+                   VERBATIM)
+add_custom_target(argparse4j_jar DEPENDS ${ARGPARSE4J_JAR})
+
+set(JAVA_C_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/java-c-headers")
+
+add_jar(ffront-java
+        INCLUDE_JARS ${ARGPARSE4J_JAR}
+        SOURCES ${ffront_java_SRC}
+        OUTPUT_NAME ffront
+        ENTRY_POINT xcodeml.f.util.main
+        OUTPUT_DIR ${INT_OMNI_HOME_SHARE}
+        GENERATE_NATIVE_HEADERS ffront-java-native-headers DESTINATION ${JAVA_C_HEADERS_DIR})
+add_dependencies(ffront-java create_int_install_dirs argparse4j argparse4j_jar)
+
+file(GLOB FFRONT_JNI_CPP_SRC "cpp/*.cpp")
+
+add_library(ffront-jni SHARED EXCLUDE_FROM_ALL ${FFRONT_JNI_CPP_SRC})
+add_dependencies(ffront-jni generate_ffront_src create_int_install_dirs ffront-java)
+set_target_properties(ffront-jni
+                      PROPERTIES
+                      LIBRARY_OUTPUT_DIRECTORY ${INT_OMNI_HOME_SHARE}
+                      OUTPUT_NAME ffront-jni)
+target_include_directories(ffront-jni PRIVATE ${FFRONT_INC_DIRS} ${JAVA_C_HEADERS_DIR} ${JNI_INCLUDE_DIRS})
+target_compile_definitions(ffront-jni PRIVATE ${FFRONT_DEFINES})
+target_link_libraries(ffront-jni ffront-cpp-shared ${JNI_LIBRARIES} ${LIBXML2_LIBRARY})
+
+else()
+  message(WARNING "JNI not found, java bindings will be unavailable")
+endif() # JNI_FOUND

--- a/F-FrontEnd-jni/src/CMakeLists.txt
+++ b/F-FrontEnd-jni/src/CMakeLists.txt
@@ -11,6 +11,7 @@ include(ExternalProject)
 
 ExternalProject_Add(
     argparse4j
+    EXCLUDE_FROM_ALL ON
     URL "${ARGPARSE4J_URL}"
     DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/3rdparty"
     DOWNLOAD_NO_EXTRACT OFF
@@ -35,6 +36,8 @@ add_jar(ffront-java
         ENTRY_POINT xcodeml.f.util.main
         OUTPUT_DIR ${INT_OMNI_HOME_SHARE}
         GENERATE_NATIVE_HEADERS ffront-java-native-headers DESTINATION ${JAVA_C_HEADERS_DIR})
+set_property(TARGET ffront-java
+             PROPERTY EXCLUDE_FROM_ALL true)
 add_dependencies(ffront-java create_int_install_dirs argparse4j argparse4j_jar)
 
 file(GLOB FFRONT_JNI_CPP_SRC "cpp/*.cpp")

--- a/F-FrontEnd-jni/src/cpp/xcodeml_f_util_FxCompiler.cpp
+++ b/F-FrontEnd-jni/src/cpp/xcodeml_f_util_FxCompiler.cpp
@@ -237,46 +237,47 @@ void set_cli_opts(const jni::Context& ctxJNI, cli_options* opts, jobject optsJav
     set_int(default_single_real_type_size);
     set_int(default_double_real_type_size);
     {
-    	auto f77 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f77");
-    	if(f77 && (*f77))
-    	{
-    		set_lang_spec_set(opts, F77_SPEC);
-    	}
+        auto f77 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f77");
+        if(f77 && (*f77))
+        {
+            set_lang_spec_set(opts, F77_SPEC);
+        }
     }
     {
-    	auto f90 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f90");
-    	if(f90 && (*f90))
-    	{
-    		set_lang_spec_set(opts, F90_SPEC);
-    	}
+        auto f90 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f90");
+        if(f90 && (*f90))
+        {
+            set_lang_spec_set(opts, F90_SPEC);
+        }
     }
     {
-    	auto f95 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f95");
-    	if(f95 && (*f95))
-    	{
-    		set_lang_spec_set(opts, F95_SPEC);
-    	}
+        auto f95 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f95");
+        if(f95 && (*f95))
+        {
+            set_lang_spec_set(opts, F95_SPEC);
+        }
     }
     set_bool(debug_enabled);
-	set_bool(yacc_debug_enabled);
-	set_bool(module_compile_enabled);
-	set_bool(omp_enabled);
-	set_bool(xmp_enabled);
-	set_bool(xmp_coarray_enabled);
-	set_bool(acc_enabled);
-	set_bool(cond_compile_enabled);
-	set_bool(leave_comment_enabled);
-	set_bool(do_implicit_undef);
-	set_bool(force_fixed_format_enabled);
-	set_bool(force_c_comments_enabled);
-	set_bool(dollar_in_id_enabled);
-	set_bool(end_line_no_enabled);
-	set_bool(ocl_enabled);
-	set_bool(cdir_enabled);
-	set_bool(pgi_enabled);
-	set_bool(module_cache_enabled);
-	set_bool(print_help);
-	set_bool(print_opts);
+    set_bool(yacc_debug_enabled);
+    set_bool(module_compile_enabled);
+    set_bool(omp_enabled);
+    set_bool(xmp_enabled);
+    set_bool(xmp_coarray_enabled);
+    set_bool(acc_enabled);
+    set_bool(cond_compile_enabled);
+    set_bool(leave_comment_enabled);
+    set_bool(do_implicit_undef);
+    set_bool(force_fixed_format_enabled);
+    set_bool(force_c_comments_enabled);
+    set_bool(dollar_in_id_enabled);
+    set_bool(end_line_no_enabled);
+    set_bool(ocl_enabled);
+    set_bool(cdir_enabled);
+    set_bool(pgi_enabled);
+    set_bool(module_cache_enabled);
+    set_bool(add_timestamp_enabled);
+    set_bool(print_help);
+    set_bool(print_opts);
 }
 
 /*

--- a/F-FrontEnd-jni/src/cpp/xcodeml_f_util_FxCompiler.cpp
+++ b/F-FrontEnd-jni/src/cpp/xcodeml_f_util_FxCompiler.cpp
@@ -1,0 +1,321 @@
+/* Author: Mikhail Zhigun */
+#include "xcodeml_f_util_FxCompiler.h"
+#include "cli_options.h"
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <iostream>
+
+extern int execute_cli_opts(const cli_options* opts);
+
+namespace jni
+{
+    class JavaExceptionDetected
+    {};
+
+    inline void assert_no_java_exception(JNIEnv * env) {
+        if (env->ExceptionCheck()==JNI_TRUE)
+            throw JavaExceptionDetected();
+    }
+
+    class Context
+    {
+    public:
+        Context(JNIEnv * env):
+            env{env},
+            Boolean{env->FindClass("java/lang/Boolean")},
+            Integer{env->FindClass("java/lang/Integer")},
+            List{env->FindClass("java/util/List")},
+            Path{env->FindClass("java/nio/file/Path")},
+            CppException{env->FindClass("xcodeml/f/util/NativeUtils$CppException")},
+            Error{env->FindClass("java/lang/Error")},
+            CLIOptions{env->FindClass("xcodeml/f/util/CLIOptions")},
+            get_list_size{env->GetMethodID(List, "size", "()I")},
+            get_list_element{env->GetMethodID(List, "get", "(I)Ljava/lang/Object;")},
+            get_integer_value{env->GetMethodID(Integer, "intValue", "()I")},
+            get_boolean_value{env->GetMethodID(Boolean, "booleanValue", "()Z")},
+            path_to_string{env->GetMethodID(Path, "toString", "()Ljava/lang/String;")}
+        {
+            assert_no_java_exception(env);
+        }
+
+        JNIEnv* const env;
+        const jclass Boolean;
+        const jclass Integer;
+        const jclass Path;
+        const jclass List;
+        const jclass CppException;
+        const jclass Error;
+        const jclass CLIOptions;
+        const jmethodID get_list_size;
+        const jmethodID get_list_element;
+        const jmethodID get_integer_value;
+        const jmethodID get_boolean_value;
+        const jmethodID path_to_string;
+    };
+
+    std::string to_string(const Context& ctxJNI, jstring str)
+    {
+        JNIEnv* const env = ctxJNI.env;
+        jboolean is_copy;
+        const char* utf8_chrs = env->GetStringUTFChars(str, &is_copy);
+        std::string res(utf8_chrs);
+        if (is_copy == JNI_TRUE) {
+            ctxJNI.env->ReleaseStringUTFChars(str, utf8_chrs);
+        }
+        assert_no_java_exception(env);
+        return res;
+    }
+
+    std::unique_ptr<std::string> get_path_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    {
+
+        JNIEnv* const env = ctxJNI.env;
+        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/nio/file/Path;");
+        assert_no_java_exception(env);
+        jobject objPath = env->GetObjectField(obj, field_id);
+        assert_no_java_exception(env);
+        std::unique_ptr<std::string> res;
+        if(env->IsSameObject(objPath, NULL) == JNI_FALSE)
+        {
+            jobject objStr = static_cast<jstring>(env->CallObjectMethod(objPath, ctxJNI.path_to_string));
+            assert_no_java_exception(env);
+            res = std::make_unique<std::string>(to_string(env, static_cast<jstring>(objStr)));
+        }
+        assert_no_java_exception(env);
+        return res;
+    }
+
+    std::vector<std::string> get_path_list_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    {
+        JNIEnv* const env = ctxJNI.env;
+        jclass List = ctxJNI.List;
+        jmethodID get_list_size = ctxJNI.get_list_size;
+        jmethodID get_list_element = ctxJNI.get_list_element;
+        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/util/List;");
+        assert_no_java_exception(env);
+        jobject field_obj = env->GetObjectField(obj, field_id);
+        assert_no_java_exception(env);
+
+        const jint len = env->CallIntMethod(field_obj, get_list_size);
+        assert_no_java_exception(env);
+        std::vector<std::string> res;
+        res.reserve(len);
+        for(int i = 0; i < len; ++i)
+        {
+            jobject elPath = static_cast<jstring>(env->CallObjectMethod(field_obj, get_list_element, i));
+            assert_no_java_exception(env);
+            jstring elStr =  static_cast<jstring>(env->CallObjectMethod(elPath, ctxJNI.path_to_string));
+            assert_no_java_exception(env);
+            res.push_back(to_string(env, elStr));
+        }
+        assert_no_java_exception(env);
+        return res;
+    }
+
+    std::unique_ptr<std::string> get_string_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    {
+
+        JNIEnv* const env = ctxJNI.env;
+        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/lang/String;");
+        jobject objStr = env->GetObjectField(obj, field_id);
+        std::unique_ptr<std::string> res;
+        if(env->IsSameObject(objStr, NULL) == JNI_FALSE)
+        {
+            res = std::make_unique<std::string>(to_string(env, static_cast<jstring>(objStr)));
+        }
+        assert_no_java_exception(env);
+        return res;
+    }
+
+    std::vector<std::string> get_string_list_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    {
+        JNIEnv* const env = ctxJNI.env;
+        jclass List = ctxJNI.List;
+        jmethodID get_list_size = ctxJNI.get_list_size;
+        jmethodID get_list_element = ctxJNI.get_list_element;
+        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/util/List;");
+        jobject field_obj = env->GetObjectField(obj, field_id);
+
+        const jint len = env->CallIntMethod(field_obj, get_list_size);
+        std::vector<std::string> res;
+        res.reserve(len);
+        for(int i = 0; i < len; ++i)
+        {
+            jstring element = static_cast<jstring>(env->CallObjectMethod(field_obj, get_list_element, i));
+            auto el_str = to_string(env, element);
+            res.push_back(move(el_str));
+        }
+        assert_no_java_exception(env);
+        return res;
+    }
+
+    std::unique_ptr<bool> get_boolean_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    {
+        JNIEnv* const env = ctxJNI.env;
+        jmethodID get_boolean_value = ctxJNI.get_boolean_value;
+        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/lang/Boolean;");
+        assert_no_java_exception(env);
+        jobject objBoolean = env->GetObjectField(obj, field_id);
+        assert_no_java_exception(env);
+        std::unique_ptr<bool> res;
+        if(env->IsSameObject(objBoolean, NULL) == JNI_FALSE)
+        {
+            jboolean val = env->CallBooleanMethod(objBoolean, get_boolean_value);
+            res = std::make_unique<bool>(val == JNI_TRUE);
+        }
+        assert_no_java_exception(env);
+        return res;
+    }
+
+    std::unique_ptr<int> get_integer_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    {
+        JNIEnv* const env = ctxJNI.env;
+        jmethodID get_integer_value = ctxJNI.get_integer_value;
+        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/lang/Integer;");
+        assert_no_java_exception(env);
+        jobject objInt = env->GetObjectField(obj, field_id);
+        assert_no_java_exception(env);
+        std::unique_ptr<int> res;
+        if(env->IsSameObject(objInt, NULL) == JNI_FALSE)
+        {
+            jint val = env->CallIntMethod(objInt, get_integer_value);
+            res = std::make_unique<int>(val);
+        }
+        assert_no_java_exception(env);
+        return res;
+    }
+
+    void rethrow_cpp_exception(const Context& ctxJNI, const char* msg)
+    {
+        JNIEnv* const env = ctxJNI.env;
+        jclass CppException = ctxJNI.CppException;
+        env->ThrowNew(CppException, msg);
+    }
+}
+
+#define set_path(field_name) \
+    { \
+        auto path = get_path_field(ctxJNI, ctxJNI.CLIOptions, optsJava, (#field_name)); \
+        if(path) \
+           set_##field_name(opts, path->c_str()); \
+    }
+#define set_path_vector(field_name) \
+    { \
+        auto paths = get_path_list_field(ctxJNI, ctxJNI.CLIOptions, optsJava, (#field_name "s")); \
+        for(const auto& path: paths) \
+           add_##field_name(opts, path.c_str()); \
+    }
+#define set_int(field_name) \
+    { \
+        auto val = get_integer_field(ctxJNI, ctxJNI.CLIOptions, optsJava, (#field_name)); \
+        if(val) \
+           set_##field_name(opts, *val); \
+    }
+#define set_bool(field_name) \
+    { \
+        auto val = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, (#field_name)); \
+        if(val) \
+           set_##field_name(opts, *val); \
+    }
+
+void set_cli_opts(const jni::Context& ctxJNI, cli_options* opts, jobject optsJava)
+{
+    using namespace jni;
+    auto get_path_list = [&](const char* field_name) { return get_path_field(ctxJNI, ctxJNI.CLIOptions, optsJava, field_name); };
+    auto get_int = [&](const char* field_name) { return get_integer_field(ctxJNI, ctxJNI.CLIOptions, optsJava, field_name); };
+    auto get_bool = [&](const char* field_name) { return get_path_list_field(ctxJNI, ctxJNI.CLIOptions, optsJava, field_name); };
+    set_path(src_file_path);
+    set_path(out_file_path);
+    set_path(intrinsic_xmod_dir_path);
+    set_path_vector(inc_dir_path);
+    set_int(max_line_len);
+    set_int(max_cont_line);
+    set_int(auto_save_attr_kb);
+    set_int(max_name_len);
+    set_int(default_single_real_type_size);
+    set_int(default_double_real_type_size);
+    {
+    	auto f77 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f77");
+    	if(f77 && (*f77))
+    	{
+    		set_lang_spec_set(opts, F77_SPEC);
+    	}
+    }
+    {
+    	auto f90 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f90");
+    	if(f90 && (*f90))
+    	{
+    		set_lang_spec_set(opts, F90_SPEC);
+    	}
+    }
+    {
+    	auto f95 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f95");
+    	if(f95 && (*f95))
+    	{
+    		set_lang_spec_set(opts, F95_SPEC);
+    	}
+    }
+    set_bool(debug_enabled);
+	set_bool(yacc_debug_enabled);
+	set_bool(module_compile_enabled);
+	set_bool(omp_enabled);
+	set_bool(xmp_enabled);
+	set_bool(xmp_coarray_enabled);
+	set_bool(acc_enabled);
+	set_bool(cond_compile_enabled);
+	set_bool(leave_comment_enabled);
+	set_bool(do_implicit_undef);
+	set_bool(force_fixed_format_enabled);
+	set_bool(force_c_comments_enabled);
+	set_bool(dollar_in_id_enabled);
+	set_bool(end_line_no_enabled);
+	set_bool(ocl_enabled);
+	set_bool(cdir_enabled);
+	set_bool(pgi_enabled);
+	set_bool(module_cache_enabled);
+	set_bool(print_help);
+	set_bool(print_opts);
+}
+
+/*
+ * Class:     xcodeml_f_util_FxCompiler
+ * Method:    execute
+ * Signature: (Lxcodeml/f/util/CLIOptions;)I
+ */
+jint JNICALL Java_xcodeml_f_util_FxCompiler_execute
+  (JNIEnv * env, jclass, jobject optsJava)
+{
+    try
+    {
+        jni::Context ctxJNI{env};
+        try
+        {
+            cli_options opts;
+            init_cli_options(&opts);
+            set_cli_opts(ctxJNI, &opts, optsJava);
+            const int ret_code = execute_cli_opts(&opts);
+           	free_cli_options(&opts);
+            return ret_code;
+        }
+        catch(const jni::JavaExceptionDetected&)
+        {
+            return 1;
+        }
+        catch(const std::exception& e)
+        {
+            jni::rethrow_cpp_exception(env, e.what());
+            return 1;
+        }
+        catch(...)
+        {
+            jni::rethrow_cpp_exception(env, "Unknown exception");
+            return 1;
+        }
+    }
+    catch(const jni::JavaExceptionDetected&)
+    {
+        return 1;
+    }
+}

--- a/F-FrontEnd-jni/src/cpp/xcodeml_f_util_FxCompiler.cpp
+++ b/F-FrontEnd-jni/src/cpp/xcodeml_f_util_FxCompiler.cpp
@@ -1,321 +1,484 @@
 /* Author: Mikhail Zhigun */
 #include "xcodeml_f_util_FxCompiler.h"
 #include "cli_options.h"
+#include "io_cache.h"
 #include <string>
 #include <vector>
 #include <memory>
 #include <functional>
 #include <iostream>
+#include <string.h>
 
-extern int execute_cli_opts(const cli_options* opts);
+extern int execute_cli_opts(const cli_options *opts, io_cache files_cache);
 
 namespace jni
 {
-    class JavaExceptionDetected
-    {};
+class JavaExceptionDetected
+{
+};
 
-    inline void assert_no_java_exception(JNIEnv * env) {
-        if (env->ExceptionCheck()==JNI_TRUE)
-            throw JavaExceptionDetected();
+void assert_no_java_exception(JNIEnv *env)
+{
+    if (env->ExceptionCheck() == JNI_TRUE)
+        throw JavaExceptionDetected();
+}
+
+void rethrow_cpp_exception(JNIEnv *env, const char *msg)
+{
+    auto CppException = env->FindClass(
+            "xcodeml/f/util/NativeUtils$CppException");
+    env->ThrowNew(CppException, msg);
+}
+
+class Context
+{
+public:
+    Context(JNIEnv *env) :
+            env
+            { env }, Boolean
+            { env->FindClass("java/lang/Boolean") }, Integer
+            { env->FindClass("java/lang/Integer") }, List
+            { env->FindClass("java/util/List") }, Path
+            { env->FindClass("java/nio/file/Path") }, CppException
+            { env->FindClass("xcodeml/f/util/NativeUtils$CppException") }, Error
+            { env->FindClass("java/lang/Error") }, CLIOptions
+            { env->FindClass("xcodeml/f/util/CLIOptions") }, IOCache
+            { env->FindClass("xcodeml/f/util/NativeUtils$IOCache") }, IOCacheInputEntry
+            { env->FindClass("xcodeml/f/util/NativeUtils$IOCacheInputEntry") }, IOCacheOutputEntry
+            { env->FindClass("xcodeml/f/util/NativeUtils$IOCacheOutputEntry") }, MappedByteBuffer
+            { env->FindClass("java/nio/MappedByteBuffer") }, get_list_size
+            { env->GetMethodID(List, "size", "()I") }, get_list_element
+            { env->GetMethodID(List, "get", "(I)Ljava/lang/Object;") }, get_integer_value
+            { env->GetMethodID(Integer, "intValue", "()I") }, get_boolean_value
+            { env->GetMethodID(Boolean, "booleanValue", "()Z") }, path_to_string
+            { env->GetMethodID(Path, "toString", "()Ljava/lang/String;") }, iocache_get_input_files
+            { env->GetMethodID(IOCache, "getInputFiles", "()Ljava/util/List;") }, iocache_get_output_files
+            { env->GetMethodID(IOCache, "getOutputFiles", "()Ljava/util/List;") }, IOCacheOutputEntry_allocateData
+            { env->GetMethodID(IOCacheOutputEntry, "allocateData", "(I)V") }
+    {
+        assert_no_java_exception(env);
     }
 
-    class Context
-    {
-    public:
-        Context(JNIEnv * env):
-            env{env},
-            Boolean{env->FindClass("java/lang/Boolean")},
-            Integer{env->FindClass("java/lang/Integer")},
-            List{env->FindClass("java/util/List")},
-            Path{env->FindClass("java/nio/file/Path")},
-            CppException{env->FindClass("xcodeml/f/util/NativeUtils$CppException")},
-            Error{env->FindClass("java/lang/Error")},
-            CLIOptions{env->FindClass("xcodeml/f/util/CLIOptions")},
-            get_list_size{env->GetMethodID(List, "size", "()I")},
-            get_list_element{env->GetMethodID(List, "get", "(I)Ljava/lang/Object;")},
-            get_integer_value{env->GetMethodID(Integer, "intValue", "()I")},
-            get_boolean_value{env->GetMethodID(Boolean, "booleanValue", "()Z")},
-            path_to_string{env->GetMethodID(Path, "toString", "()Ljava/lang/String;")}
-        {
-            assert_no_java_exception(env);
-        }
+    JNIEnv *const env;
+    const jclass Boolean;
+    const jclass Integer;
+    const jclass Path;
+    const jclass List;
+    const jclass CppException;
+    const jclass Error;
+    const jclass CLIOptions;
+    const jclass IOCache;
+    const jclass IOCacheInputEntry;
+    const jclass IOCacheOutputEntry;
+    const jclass MappedByteBuffer;
+    const jmethodID get_list_size;
+    const jmethodID get_list_element;
+    const jmethodID get_integer_value;
+    const jmethodID get_boolean_value;
+    const jmethodID path_to_string;
+    const jmethodID iocache_get_input_files;
+    const jmethodID iocache_get_output_files;
+    const jmethodID IOCacheOutputEntry_allocateData;
+};
 
-        JNIEnv* const env;
-        const jclass Boolean;
-        const jclass Integer;
-        const jclass Path;
-        const jclass List;
-        const jclass CppException;
-        const jclass Error;
-        const jclass CLIOptions;
-        const jmethodID get_list_size;
-        const jmethodID get_list_element;
-        const jmethodID get_integer_value;
-        const jmethodID get_boolean_value;
-        const jmethodID path_to_string;
-    };
+class Functions: Context
+{
+    using Context::Context;
 
-    std::string to_string(const Context& ctxJNI, jstring str)
+    void assert_no_java_exception()
     {
-        JNIEnv* const env = ctxJNI.env;
+        ::jni::assert_no_java_exception(env);
+    }
+
+    std::string to_string(jstring str)
+    {
         jboolean is_copy;
-        const char* utf8_chrs = env->GetStringUTFChars(str, &is_copy);
+        const char *utf8_chrs = env->GetStringUTFChars(str, &is_copy);
         std::string res(utf8_chrs);
-        if (is_copy == JNI_TRUE) {
-            ctxJNI.env->ReleaseStringUTFChars(str, utf8_chrs);
-        }
-        assert_no_java_exception(env);
-        return res;
-    }
-
-    std::unique_ptr<std::string> get_path_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
-    {
-
-        JNIEnv* const env = ctxJNI.env;
-        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/nio/file/Path;");
-        assert_no_java_exception(env);
-        jobject objPath = env->GetObjectField(obj, field_id);
-        assert_no_java_exception(env);
-        std::unique_ptr<std::string> res;
-        if(env->IsSameObject(objPath, NULL) == JNI_FALSE)
+        if (is_copy == JNI_TRUE)
         {
-            jobject objStr = static_cast<jstring>(env->CallObjectMethod(objPath, ctxJNI.path_to_string));
-            assert_no_java_exception(env);
-            res = std::make_unique<std::string>(to_string(env, static_cast<jstring>(objStr)));
+            env->ReleaseStringUTFChars(str, utf8_chrs);
         }
-        assert_no_java_exception(env);
+        assert_no_java_exception();
         return res;
     }
 
-    std::vector<std::string> get_path_list_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    std::unique_ptr<std::string> get_path_field(jclass cls, jobject obj,
+            const char *field_name)
     {
-        JNIEnv* const env = ctxJNI.env;
-        jclass List = ctxJNI.List;
-        jmethodID get_list_size = ctxJNI.get_list_size;
-        jmethodID get_list_element = ctxJNI.get_list_element;
-        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/util/List;");
-        assert_no_java_exception(env);
+
+        jfieldID field_id = env->GetFieldID(cls, field_name,
+                "Ljava/nio/file/Path;");
+        assert_no_java_exception();
+        jobject objPath = env->GetObjectField(obj, field_id);
+        assert_no_java_exception();
+        std::unique_ptr<std::string> res;
+        if (env->IsSameObject(objPath, NULL) == JNI_FALSE)
+        {
+            jobject objStr = static_cast<jstring>(env->CallObjectMethod(objPath,
+                    path_to_string));
+            assert_no_java_exception();
+            res = std::make_unique<std::string>(
+                    to_string(static_cast<jstring>(objStr)));
+        }
+        assert_no_java_exception();
+        return res;
+    }
+
+    std::vector<std::string> get_path_list_field(jclass cls, jobject obj,
+            const char *field_name)
+    {
+        jfieldID field_id = env->GetFieldID(cls, field_name,
+                "Ljava/util/List;");
+        assert_no_java_exception();
         jobject field_obj = env->GetObjectField(obj, field_id);
-        assert_no_java_exception(env);
+        assert_no_java_exception();
 
         const jint len = env->CallIntMethod(field_obj, get_list_size);
-        assert_no_java_exception(env);
+        assert_no_java_exception();
         std::vector<std::string> res;
         res.reserve(len);
-        for(int i = 0; i < len; ++i)
+        for (int i = 0; i < len; ++i)
         {
-            jobject elPath = static_cast<jstring>(env->CallObjectMethod(field_obj, get_list_element, i));
-            assert_no_java_exception(env);
-            jstring elStr =  static_cast<jstring>(env->CallObjectMethod(elPath, ctxJNI.path_to_string));
-            assert_no_java_exception(env);
-            res.push_back(to_string(env, elStr));
+            jobject elPath = static_cast<jstring>(env->CallObjectMethod(
+                    field_obj, get_list_element, i));
+            assert_no_java_exception();
+            jstring elStr = static_cast<jstring>(env->CallObjectMethod(elPath,
+                    path_to_string));
+            assert_no_java_exception();
+            res.push_back(to_string(elStr));
         }
-        assert_no_java_exception(env);
+        assert_no_java_exception();
         return res;
     }
 
-    std::unique_ptr<std::string> get_string_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    std::unique_ptr<std::string> get_string_field(jclass cls, jobject obj,
+            const char *field_name)
     {
 
-        JNIEnv* const env = ctxJNI.env;
-        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/lang/String;");
+        jfieldID field_id = env->GetFieldID(cls, field_name,
+                "Ljava/lang/String;");
         jobject objStr = env->GetObjectField(obj, field_id);
         std::unique_ptr<std::string> res;
-        if(env->IsSameObject(objStr, NULL) == JNI_FALSE)
+        if (env->IsSameObject(objStr, NULL) == JNI_FALSE)
         {
-            res = std::make_unique<std::string>(to_string(env, static_cast<jstring>(objStr)));
+            res = std::make_unique<std::string>(
+                    to_string(static_cast<jstring>(objStr)));
         }
-        assert_no_java_exception(env);
+        assert_no_java_exception();
         return res;
     }
 
-    std::vector<std::string> get_string_list_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    std::vector<std::string> get_string_list_field(jclass cls, jobject obj,
+            const char *field_name)
     {
-        JNIEnv* const env = ctxJNI.env;
-        jclass List = ctxJNI.List;
-        jmethodID get_list_size = ctxJNI.get_list_size;
-        jmethodID get_list_element = ctxJNI.get_list_element;
-        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/util/List;");
+        jfieldID field_id = env->GetFieldID(cls, field_name,
+                "Ljava/util/List;");
         jobject field_obj = env->GetObjectField(obj, field_id);
 
         const jint len = env->CallIntMethod(field_obj, get_list_size);
         std::vector<std::string> res;
         res.reserve(len);
-        for(int i = 0; i < len; ++i)
+        for (int i = 0; i < len; ++i)
         {
-            jstring element = static_cast<jstring>(env->CallObjectMethod(field_obj, get_list_element, i));
-            auto el_str = to_string(env, element);
+            jstring element = static_cast<jstring>(env->CallObjectMethod(
+                    field_obj, get_list_element, i));
+            auto el_str = to_string(element);
             res.push_back(move(el_str));
         }
-        assert_no_java_exception(env);
+        assert_no_java_exception();
         return res;
     }
 
-    std::unique_ptr<bool> get_boolean_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    std::unique_ptr<bool> get_boolean_field(jclass cls, jobject obj,
+            const char *field_name)
     {
-        JNIEnv* const env = ctxJNI.env;
-        jmethodID get_boolean_value = ctxJNI.get_boolean_value;
-        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/lang/Boolean;");
-        assert_no_java_exception(env);
+        jfieldID field_id = env->GetFieldID(cls, field_name,
+                "Ljava/lang/Boolean;");
+        assert_no_java_exception();
         jobject objBoolean = env->GetObjectField(obj, field_id);
-        assert_no_java_exception(env);
+        assert_no_java_exception();
         std::unique_ptr<bool> res;
-        if(env->IsSameObject(objBoolean, NULL) == JNI_FALSE)
+        if (env->IsSameObject(objBoolean, NULL) == JNI_FALSE)
         {
-            jboolean val = env->CallBooleanMethod(objBoolean, get_boolean_value);
+            jboolean val = env->CallBooleanMethod(objBoolean,
+                    get_boolean_value);
             res = std::make_unique<bool>(val == JNI_TRUE);
         }
-        assert_no_java_exception(env);
+        assert_no_java_exception();
         return res;
     }
 
-    std::unique_ptr<int> get_integer_field(const Context& ctxJNI, jclass cls, jobject obj, const char* field_name)
+    std::unique_ptr<int> get_integer_field(jclass cls, jobject obj,
+            const char *field_name)
     {
-        JNIEnv* const env = ctxJNI.env;
-        jmethodID get_integer_value = ctxJNI.get_integer_value;
-        jfieldID field_id = env->GetFieldID(cls, field_name, "Ljava/lang/Integer;");
-        assert_no_java_exception(env);
+        jfieldID field_id = env->GetFieldID(cls, field_name,
+                "Ljava/lang/Integer;");
+        assert_no_java_exception();
         jobject objInt = env->GetObjectField(obj, field_id);
-        assert_no_java_exception(env);
+        assert_no_java_exception();
         std::unique_ptr<int> res;
-        if(env->IsSameObject(objInt, NULL) == JNI_FALSE)
+        if (env->IsSameObject(objInt, NULL) == JNI_FALSE)
         {
             jint val = env->CallIntMethod(objInt, get_integer_value);
             res = std::make_unique<int>(val);
         }
-        assert_no_java_exception(env);
+        assert_no_java_exception();
         return res;
     }
 
-    void rethrow_cpp_exception(const Context& ctxJNI, const char* msg)
+    int get_int_field(jclass cls, jobject obj, const char *field_name)
     {
-        JNIEnv* const env = ctxJNI.env;
-        jclass CppException = ctxJNI.CppException;
+        jfieldID field_id = env->GetFieldID(cls, field_name, "I");
+        assert_no_java_exception();
+        const int val = env->GetIntField(obj, field_id);
+        assert_no_java_exception();
+        return val;
+    }
+
+    jobject get_mappedbytebuf_field(jclass cls, jobject obj,
+            const char *field_name)
+    {
+        jfieldID field_id = env->GetFieldID(cls, field_name,
+                "Ljava/nio/MappedByteBuffer;");
+        assert_no_java_exception();
+        jobject buf = env->GetObjectField(obj, field_id);
+        return buf;
+    }
+
+    void rethrow_cpp_exception(const char *msg)
+    {
         env->ThrowNew(CppException, msg);
     }
-}
+
+public:
+    io_cache create_cache(jobject jFilesCache)
+    {
+        io_cache filesCache = create_io_cache();
+        {
+            jobject inputFilesEntries = env->CallObjectMethod(jFilesCache,
+                    iocache_get_input_files);
+            assert_no_java_exception();
+            const jint inputFilesEntriesLen = env->CallIntMethod(
+                    inputFilesEntries, get_list_size);
+            assert_no_java_exception();
+            for (int i = 0; i < inputFilesEntriesLen; ++i)
+            {
+                jobject entry = env->CallObjectMethod(inputFilesEntries,
+                        get_list_element, i);
+                assert_no_java_exception();
+                const auto filename = get_string_field(IOCacheInputEntry, entry,
+                        "filename");
+                const size_t size = (size_t) get_int_field(IOCacheInputEntry,
+                        entry, "size");
+                jobject mappedBufObj = get_mappedbytebuf_field(
+                        IOCacheInputEntry, entry, "data");
+                void *mappedBuf = env->GetDirectBufferAddress(mappedBufObj);
+                assert_no_java_exception();
+                if (!mappedBuf)
+                {
+                    throw std::runtime_error(
+                            "GetDirectBufferAddress failed");
+                }
+                io_cache_add_input_file(filesCache, filename->c_str(),
+                        mappedBuf, size);
+            }
+        }
+        {
+            jobject outputFilesEntries = env->CallObjectMethod(jFilesCache,
+                    iocache_get_output_files);
+            assert_no_java_exception();
+            const jint outputFilesEntriesLen = env->CallIntMethod(
+                    outputFilesEntries, get_list_size);
+            assert_no_java_exception();
+            for (int i = 0; i < outputFilesEntriesLen; ++i)
+            {
+                jobject entry = env->CallObjectMethod(outputFilesEntries,
+                        get_list_element, i);
+                assert_no_java_exception();
+                const auto filename = get_string_field(IOCacheInputEntry, entry,
+                        "filename");
+                io_cache_add_output_file(filesCache, filename->c_str());
+            }
+
+        }
+        return filesCache;
+    }
+
+    void update_cache(jobject jFilesCache, io_cache filesCache)
+    {
+        jobject outputFilesEntries = env->CallObjectMethod(jFilesCache,
+                iocache_get_output_files);
+        assert_no_java_exception();
+        const jint outputFilesEntriesLen = env->CallIntMethod(
+                outputFilesEntries, get_list_size);
+        assert_no_java_exception();
+        for (int i = 0; i < outputFilesEntriesLen; ++i)
+        {
+            jobject entry = env->CallObjectMethod(outputFilesEntries,
+                    get_list_element, i);
+            assert_no_java_exception();
+            const auto filename = get_string_field(IOCacheOutputEntry, entry,
+                    "filename");
+            void *startAddress = nullptr;
+            size_t size = 0;
+            io_cache_get_output_file_as_mem(filesCache, filename->c_str(),
+                    &startAddress, &size);
+            env->CallVoidMethod(entry, IOCacheOutputEntry_allocateData,
+                    (int) size);
+            assert_no_java_exception();
+            if(size > 0)
+            {
+                jobject mappedBufObj = get_mappedbytebuf_field(IOCacheOutputEntry,
+                        entry, "data");
+                void *mappedBuf = env->GetDirectBufferAddress(mappedBufObj);
+                assert_no_java_exception();
+                memcpy(mappedBuf, startAddress, size);
+            }
+        }
+    }
 
 #define set_path(field_name) \
     { \
-        auto path = get_path_field(ctxJNI, ctxJNI.CLIOptions, optsJava, (#field_name)); \
+        auto path = get_path_field(CLIOptions, optsJava, (#field_name)); \
         if(path) \
            set_##field_name(opts, path->c_str()); \
     }
 #define set_path_vector(field_name) \
     { \
-        auto paths = get_path_list_field(ctxJNI, ctxJNI.CLIOptions, optsJava, (#field_name "s")); \
+        auto paths = get_path_list_field(CLIOptions, optsJava, (#field_name "s")); \
         for(const auto& path: paths) \
            add_##field_name(opts, path.c_str()); \
     }
 #define set_int(field_name) \
     { \
-        auto val = get_integer_field(ctxJNI, ctxJNI.CLIOptions, optsJava, (#field_name)); \
+        auto val = get_integer_field(CLIOptions, optsJava, (#field_name)); \
         if(val) \
            set_##field_name(opts, *val); \
     }
 #define set_bool(field_name) \
     { \
-        auto val = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, (#field_name)); \
+        auto val = get_boolean_field(CLIOptions, optsJava, (#field_name)); \
         if(val) \
            set_##field_name(opts, *val); \
     }
 
-void set_cli_opts(const jni::Context& ctxJNI, cli_options* opts, jobject optsJava)
-{
-    using namespace jni;
-    auto get_path_list = [&](const char* field_name) { return get_path_field(ctxJNI, ctxJNI.CLIOptions, optsJava, field_name); };
-    auto get_int = [&](const char* field_name) { return get_integer_field(ctxJNI, ctxJNI.CLIOptions, optsJava, field_name); };
-    auto get_bool = [&](const char* field_name) { return get_path_list_field(ctxJNI, ctxJNI.CLIOptions, optsJava, field_name); };
-    set_path(src_file_path);
-    set_path(out_file_path);
-    set_path(intrinsic_xmod_dir_path);
-    set_path_vector(inc_dir_path);
-    set_int(max_line_len);
-    set_int(max_cont_line);
-    set_int(auto_save_attr_kb);
-    set_int(max_name_len);
-    set_int(default_single_real_type_size);
-    set_int(default_double_real_type_size);
+    void set_cli_opts(cli_options *opts, jobject optsJava)
     {
-        auto f77 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f77");
-        if(f77 && (*f77))
+        using namespace jni;
+        auto get_path_list = [&](const char *field_name)
         {
-            set_lang_spec_set(opts, F77_SPEC);
-        }
-    }
-    {
-        auto f90 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f90");
-        if(f90 && (*f90))
+            return get_path_field(CLIOptions, optsJava, field_name);
+        };
+        auto get_int = [&](const char *field_name)
         {
-            set_lang_spec_set(opts, F90_SPEC);
-        }
-    }
-    {
-        auto f95 = get_boolean_field(ctxJNI, ctxJNI.CLIOptions, optsJava, "lang_f95");
-        if(f95 && (*f95))
+            return get_integer_field(CLIOptions, optsJava, field_name);
+        };
+        auto get_bool = [&](const char *field_name)
         {
-            set_lang_spec_set(opts, F95_SPEC);
+            return get_path_list_field(CLIOptions, optsJava, field_name);
+        };
+        set_path(src_file_path);
+        set_path(out_file_path);
+        set_path(intrinsic_xmod_dir_path);
+        set_path_vector(inc_dir_path);
+        set_int(max_line_len);
+        set_int(max_cont_line);
+        set_int(auto_save_attr_kb);
+        set_int(max_name_len);
+        set_int(default_single_real_type_size);
+        set_int(default_double_real_type_size);
+        {
+            auto f77 = get_boolean_field(CLIOptions, optsJava, "lang_f77");
+            if (f77 && (*f77))
+            {
+                set_lang_spec_set(opts, F77_SPEC);
+            }
         }
+        {
+            auto f90 = get_boolean_field(CLIOptions, optsJava, "lang_f90");
+            if (f90 && (*f90))
+            {
+                set_lang_spec_set(opts, F90_SPEC);
+            }
+        }
+        {
+            auto f95 = get_boolean_field(CLIOptions, optsJava, "lang_f95");
+            if (f95 && (*f95))
+            {
+                set_lang_spec_set(opts, F95_SPEC);
+            }
+        }
+        set_bool(debug_enabled);
+        set_bool(yacc_debug_enabled);
+        set_bool(module_compile_enabled);
+        set_bool(omp_enabled);
+        set_bool(xmp_enabled);
+        set_bool(xmp_coarray_enabled);
+        set_bool(acc_enabled);
+        set_bool(cond_compile_enabled);
+        set_bool(leave_comment_enabled);
+        set_bool(do_implicit_undef);
+        set_bool(force_fixed_format_enabled);
+        set_bool(force_c_comments_enabled);
+        set_bool(dollar_in_id_enabled);
+        set_bool(end_line_no_enabled);
+        set_bool(ocl_enabled);
+        set_bool(cdir_enabled);
+        set_bool(pgi_enabled);
+        set_bool(module_cache_enabled);
+        set_bool(add_timestamp_enabled);
+        set_bool(print_help);
+        set_bool(print_opts);
     }
-    set_bool(debug_enabled);
-    set_bool(yacc_debug_enabled);
-    set_bool(module_compile_enabled);
-    set_bool(omp_enabled);
-    set_bool(xmp_enabled);
-    set_bool(xmp_coarray_enabled);
-    set_bool(acc_enabled);
-    set_bool(cond_compile_enabled);
-    set_bool(leave_comment_enabled);
-    set_bool(do_implicit_undef);
-    set_bool(force_fixed_format_enabled);
-    set_bool(force_c_comments_enabled);
-    set_bool(dollar_in_id_enabled);
-    set_bool(end_line_no_enabled);
-    set_bool(ocl_enabled);
-    set_bool(cdir_enabled);
-    set_bool(pgi_enabled);
-    set_bool(module_cache_enabled);
-    set_bool(add_timestamp_enabled);
-    set_bool(print_help);
-    set_bool(print_opts);
+
+};
 }
 
 /*
  * Class:     xcodeml_f_util_FxCompiler
  * Method:    execute
- * Signature: (Lxcodeml/f/util/CLIOptions;)I
+ * Signature: (Lxcodeml/f/util/CLIOptions;Lxcodeml/f/util/NativeUtils/IOCache;)I
  */
-jint JNICALL Java_xcodeml_f_util_FxCompiler_execute
-  (JNIEnv * env, jclass, jobject optsJava)
+jint JNICALL Java_xcodeml_f_util_FxCompiler_execute(JNIEnv *env, jclass,
+        jobject optsJava, jobject jFilesCache)
 {
     try
     {
-        jni::Context ctxJNI{env};
+        jni::Functions ctx
+        { env };
         try
         {
             cli_options opts;
             init_cli_options(&opts);
-            set_cli_opts(ctxJNI, &opts, optsJava);
-            const int ret_code = execute_cli_opts(&opts);
-           	free_cli_options(&opts);
+            ctx.set_cli_opts(&opts, optsJava);
+            int ret_code;
+            if (env->IsSameObject(jFilesCache, NULL) == JNI_TRUE)
+            {
+                ret_code = execute_cli_opts(&opts, nullptr);
+            }
+            else
+            {
+                io_cache filesCache = ctx.create_cache(jFilesCache);
+                ret_code = execute_cli_opts(&opts, filesCache);
+                ctx.update_cache(jFilesCache, filesCache);
+                free_io_cache(filesCache);
+            }
+            free_cli_options(&opts);
             return ret_code;
-        }
-        catch(const jni::JavaExceptionDetected&)
+        } catch (const jni::JavaExceptionDetected&)
         {
             return 1;
-        }
-        catch(const std::exception& e)
+        } catch (const std::exception &e)
         {
             jni::rethrow_cpp_exception(env, e.what());
             return 1;
-        }
-        catch(...)
+        } catch (...)
         {
             jni::rethrow_cpp_exception(env, "Unknown exception");
             return 1;
         }
-    }
-    catch(const jni::JavaExceptionDetected&)
+    } catch (const jni::JavaExceptionDetected&)
     {
         return 1;
     }

--- a/F-FrontEnd-jni/src/java/xcodeml/f/util/CLIOptions.java
+++ b/F-FrontEnd-jni/src/java/xcodeml/f/util/CLIOptions.java
@@ -1,0 +1,368 @@
+/*
+ * @author Mikhail Zhigun
+ */
+package xcodeml.f.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+public class CLIOptions
+{
+    final Path src_file_path;
+    final Path out_file_path;
+    final Path intrinsic_xmod_dir_path;
+    final List<Path> inc_dir_paths;
+    final List<Path> xmod_inc_dir_paths;
+    final Integer max_line_len;
+    final Integer max_cont_line;
+    final Integer auto_save_attr_kb;
+    final Integer max_name_len;
+    final Integer default_single_real_type_size;
+    final Integer default_double_real_type_size;
+    final Boolean lang_f77;
+    final Boolean lang_f90;
+    final Boolean lang_f95;
+    final Boolean debug_enabled;
+    final Boolean yacc_debug_enabled;
+    final Boolean module_compile_enabled;
+    final Boolean omp_enabled;
+    final Boolean xmp_enabled;
+    final Boolean xmp_coarray_enabled;
+    final Boolean acc_enabled;
+    final Boolean cond_compile_enabled;
+    final Boolean leave_comment_enabled;
+    final Boolean do_implicit_undef;
+    final Boolean force_fixed_format_enabled;
+    final Boolean force_c_comments_enabled;
+    final Boolean dollar_in_id_enabled;
+    final Boolean end_line_no_enabled;
+    final Boolean ocl_enabled;
+    final Boolean cdir_enabled;
+    final Boolean pgi_enabled;
+    final Boolean module_cache_enabled;
+    final Boolean print_help;
+    final Boolean print_opts;
+
+    public static CLIOptions parseCmdlineArguments(String[] args, Path workingDir) throws Exception
+    {
+        ArgumentParser parser = ArgumentParsers.newFor("FFront").build().description("FFront is a "
+                + "source-to-source compiler which translates Fortran source into XcodeML intermediate representation");
+        Namespace parsedArgs = null;
+        try
+        {
+            parser.addArgument("fortran-file").help("Input file");
+            parser.addArgument("-o", "--output-file").help("output file path");
+            parser.addArgument("-fintrinsic-xmodules-path").help("intrinsic xmod include dir");
+            parser.addArgument("-I", "--pp-include-dir").nargs("*").action(Arguments.append()).help(
+                    "Add the directory to the search path for include files reference in preprocessor directives");
+            parser.addArgument("-M", "-MI", "--mod-include-dir").nargs("*").action(Arguments.append())
+                    .help("Add directory to the search path for .xmod files.");
+            parser.addArgument("-d").action(Arguments.storeTrue()).help("enable debug mode");
+            parser.addArgument("-yd").action(Arguments.storeTrue()).help("enable YACC debug mode");
+            parser.addArgument("-no-module-cache").action(Arguments.storeFalse()).help("always load module from file");
+            parser.addArgument("-module-compile").action(Arguments.storeTrue()).help("only generate Xmod file ");
+            parser.addArgument("-print-help").action(Arguments.storeTrue()).help("print help");
+            parser.addArgument("-print-opts").action(Arguments.storeTrue()).help("print CLI options");
+            parser.addArgument("-fopenmp").action(Arguments.storeTrue()).help("enable openmp translation");
+            parser.addArgument("-facc").action(Arguments.storeTrue()).help("enable OpenACC translation");
+            parser.addArgument("-fxmp").action(Arguments.storeTrue()).help("enable XcalableMP translation");
+            parser.addArgument("-pgi").action(Arguments.storeTrue()).help("keep PGI directives");
+            parser.addArgument("-fno-xmp-coarray").action(Arguments.storeFalse())
+                    .help("disable translation coarray statements to XcalableMP subroutine calls");
+            parser.addArgument("-Kscope-omp").action(Arguments.storeTrue()).help("enable conditional compilation");
+            MutuallyExclusiveGroup fOpts = parser.addMutuallyExclusiveGroup("Format options");
+            fOpts.addArgument("-force-fixed-format").action(Arguments.storeTrue()).help("read file as fixed format");
+            parser.addArgument("-max-line-length").type(Integer.class)
+                    .help("set max columns in a line (default is 72 in fixed format and 132 in free format)");
+            parser.addArgument("-max-cont-line").type(Integer.class)
+                    .help("set max number of continuation lines (default n=255)");
+            parser.addArgument("-force-c-comment").action(Arguments.storeTrue())
+                    .help("enable 'c' comment in free format");
+            MutuallyExclusiveGroup lOpts = parser.addMutuallyExclusiveGroup("Language  options");
+            lOpts.addArgument("-f77").action(Arguments.storeTrue()).help("use F77 spec intrinsic");
+            lOpts.addArgument("-f90").action(Arguments.storeTrue()).help("use F90 spec intrinsic");
+            lOpts.addArgument("-f95").action(Arguments.storeTrue()).help("use F95 spec intrinsic");
+            parser.addArgument("-u").action(Arguments.storeTrue()).help("use no implicit type");
+            parser.addArgument("-r", "--single-prec-size").type(Integer.class).choices(4, 8)
+                    .help("set single precision size (default N=4)");
+            parser.addArgument("--double-prec-size").type(Integer.class).choices(4, 8)
+                    .help("set double precision size (default N=8)");
+            parser.addArgument("--save").type(Integer.class).help(
+                    "add save attribute n kbytes except in a recursive function and common variables (default n=1)");
+            parser.addArgument("-max-name-len").type(Integer.class).help("set maximum identifier name length");
+            parser.addArgument("-fdollar-ok").action(Arguments.storeTrue()).help("enable using '$' in identifier");
+            parser.addArgument("-fleave-comment").action(Arguments.storeTrue()).help("leave comment in xcodeml file");
+            parser.addArgument("-endlineno").action(Arguments.storeTrue()).help("output the endlineno attribute");
+            parser.addArgument("-ocl").action(Arguments.storeTrue()).help("enable ocl");
+            parser.addArgument("-cdir").action(Arguments.storeTrue()).help("enable cdir");
+            parsedArgs = parser.parseArgs(args);
+        } catch (HelpScreenException hse)
+        {
+            return null;
+        } catch (ArgumentParserException ape)
+        {
+            parser.handleError(ape);
+            throw ape;
+        }
+        CLIOptions opts = new CLIOptions(parsedArgs, workingDir);
+        return opts;
+    }
+
+    CLIOptions(Namespace parsedArgs, Path workingDir) throws Exception
+    {
+        src_file_path = getOptionalPath(parsedArgs, workingDir, "fortran_file");
+        out_file_path = getOptionalPath(parsedArgs, workingDir, "output_file");
+        intrinsic_xmod_dir_path = getOptionalPath(parsedArgs, workingDir, "fintrinsic_xmodules_path");
+        inc_dir_paths = getPathList(parsedArgs, workingDir, "pp_include_dir");
+        xmod_inc_dir_paths = getPathList(parsedArgs, workingDir, "mod_include_dir");
+        omp_enabled = parsedArgs.getBoolean("fopenmp");
+        acc_enabled = parsedArgs.getBoolean("facc");
+        xmp_enabled = parsedArgs.getBoolean("fxmp");
+        pgi_enabled = parsedArgs.getBoolean("pgi");
+        xmp_coarray_enabled = parsedArgs.getBoolean("fno_xmp_coarray");
+        cond_compile_enabled = parsedArgs.getBoolean("Kscope_omp");
+        force_fixed_format_enabled = parsedArgs.getBoolean("force_fixed_format");
+        max_line_len = parsedArgs.getInt("max_line_length");
+        max_cont_line = parsedArgs.getInt("max_cont_line");
+        force_c_comments_enabled = parsedArgs.getBoolean("force_c_comment");
+        lang_f77 = parsedArgs.getBoolean("f77");
+        lang_f90 = parsedArgs.getBoolean("f90");
+        lang_f95 = parsedArgs.getBoolean("f95");
+        do_implicit_undef = parsedArgs.getBoolean("u");
+        default_single_real_type_size = parsedArgs.getInt("single_prec_size");
+        default_double_real_type_size = parsedArgs.getInt("double_prec_size");
+        auto_save_attr_kb = parsedArgs.getInt("save");
+        max_name_len = parsedArgs.getInt("max_name_len");
+        dollar_in_id_enabled = parsedArgs.getBoolean("fdollar_ok");
+        leave_comment_enabled = parsedArgs.getBoolean("fleave_comment");
+        end_line_no_enabled = parsedArgs.getBoolean("endlineno");
+        debug_enabled = parsedArgs.getBoolean("d");
+        yacc_debug_enabled = parsedArgs.getBoolean("yd");
+        module_cache_enabled = parsedArgs.getBoolean("no_module_cache");
+        module_compile_enabled = parsedArgs.getBoolean("module_compile");
+        print_help = parsedArgs.getBoolean("print_help");
+        print_opts = parsedArgs.getBoolean("print_opts");
+        ocl_enabled = parsedArgs.getBoolean("ocl");
+        cdir_enabled = parsedArgs.getBoolean("cdir");
+    }
+
+    static Path getOptionalPath(Namespace parsedArgs, Path workingDir, String name)
+    {
+        String str = parsedArgs.getString(name);
+        Path path = null;
+        if (str != null)
+        {
+            path = toAbsPath(workingDir, str);
+        }
+        return path;
+    }
+
+    static List<Path> getPathList(Namespace parsedArgs, Path workingDir, String name)
+    {
+        List<Path> res = new ArrayList<Path>();
+        List<List<String>> strs = parsedArgs.<List<String>>getList(name);
+        if (strs != null)
+        {
+            for (List<String> lstStr : strs)
+            {
+                for (String s : lstStr)
+                {
+                    res.add(toAbsPath(workingDir, s));
+                }
+            }
+        }
+        return Collections.unmodifiableList(res);
+    }
+
+    static Path toAbsPath(Path workingDir, String pathStr)
+    {
+        Path path = Paths.get(pathStr);
+        if (!path.isAbsolute())
+        {
+            path = workingDir.resolve(path);
+        }
+        path = path.normalize();
+        return path;
+    }
+
+    public Path getSrc_file_path()
+    {
+        return src_file_path;
+    }
+
+    public Path getOut_file_path()
+    {
+        return out_file_path;
+    }
+
+    public Path getIntrinsic_xmod_dir_path()
+    {
+        return intrinsic_xmod_dir_path;
+    }
+
+    public List<Path> getInc_dir_paths()
+    {
+        return inc_dir_paths;
+    }
+
+    public List<Path> getXmod_inc_dir_paths()
+    {
+        return xmod_inc_dir_paths;
+    }
+
+    public Integer getMax_line_len()
+    {
+        return max_line_len;
+    }
+
+    public Integer getMax_cont_line()
+    {
+        return max_cont_line;
+    }
+
+    public Integer getAuto_save_attr_kb()
+    {
+        return auto_save_attr_kb;
+    }
+
+    public Integer getMax_name_len()
+    {
+        return max_name_len;
+    }
+
+    public Integer getDefault_single_real_type()
+    {
+        return default_single_real_type_size;
+    }
+
+    public Integer getDefault_double_real_type()
+    {
+        return default_double_real_type_size;
+    }
+
+    public Boolean getLang_f77()
+    {
+        return lang_f77;
+    }
+
+    public Boolean getLang_f90()
+    {
+        return lang_f90;
+    }
+
+    public Boolean getLang_f95()
+    {
+        return lang_f95;
+    }
+
+    public Boolean getDebug_enabled()
+    {
+        return debug_enabled;
+    }
+
+    public Boolean getYacc_debug_enabled()
+    {
+        return yacc_debug_enabled;
+    }
+
+    public Boolean getModule_compile_enabled()
+    {
+        return module_compile_enabled;
+    }
+
+    public Boolean getOmp_enabled()
+    {
+        return omp_enabled;
+    }
+
+    public Boolean getXmp_enabled()
+    {
+        return xmp_enabled;
+    }
+
+    public Boolean getXmp_coarray_disabled()
+    {
+        return xmp_coarray_enabled;
+    }
+
+    public Boolean getAcc_enabled()
+    {
+        return acc_enabled;
+    }
+
+    public Boolean getCond_compile_enabled()
+    {
+        return cond_compile_enabled;
+    }
+
+    public Boolean getLeave_comment_enabled()
+    {
+        return leave_comment_enabled;
+    }
+
+    public Boolean getDo_implicit_undef()
+    {
+        return do_implicit_undef;
+    }
+
+    public Boolean getForce_fixed_format_enabled()
+    {
+        return force_fixed_format_enabled;
+    }
+
+    public Boolean getForce_c_comments_enabled()
+    {
+        return force_c_comments_enabled;
+    }
+
+    public Boolean getDollar_in_id_enabled()
+    {
+        return dollar_in_id_enabled;
+    }
+
+    public Boolean getEnd_line_no_enabled()
+    {
+        return end_line_no_enabled;
+    }
+
+    public Boolean getOcl_enabled()
+    {
+        return ocl_enabled;
+    }
+
+    public Boolean getCdir_enabled()
+    {
+        return cdir_enabled;
+    }
+
+    public Boolean getPgi_enabled()
+    {
+        return pgi_enabled;
+    }
+
+    public Boolean getModule_cache_disabled()
+    {
+        return module_cache_enabled;
+    }
+
+    public Boolean getPrint_help()
+    {
+        return print_help;
+    }
+
+    public Boolean getPrint_opts()
+    {
+        return print_opts;
+    }
+}

--- a/F-FrontEnd-jni/src/java/xcodeml/f/util/CLIOptions.java
+++ b/F-FrontEnd-jni/src/java/xcodeml/f/util/CLIOptions.java
@@ -61,7 +61,7 @@ public class CLIOptions
         Namespace parsedArgs = null;
         try
         {
-            parser.addArgument("fortran-file").help("Input file");
+            parser.addArgument("fortran-file").nargs("?").help("Input file");
             parser.addArgument("-o", "--output-file").help("output file path");
             parser.addArgument("-fintrinsic-xmodules-path").help("intrinsic xmod include dir");
             parser.addArgument("-I", "--pp-include-dir").nargs("*").action(Arguments.append()).help(

--- a/F-FrontEnd-jni/src/java/xcodeml/f/util/CLIOptions.java
+++ b/F-FrontEnd-jni/src/java/xcodeml/f/util/CLIOptions.java
@@ -51,6 +51,7 @@ public class CLIOptions
     final Boolean cdir_enabled;
     final Boolean pgi_enabled;
     final Boolean module_cache_enabled;
+    final Boolean add_timestamp_enabled;
     final Boolean print_help;
     final Boolean print_opts;
 
@@ -106,6 +107,7 @@ public class CLIOptions
             parser.addArgument("-endlineno").action(Arguments.storeTrue()).help("output the endlineno attribute");
             parser.addArgument("-ocl").action(Arguments.storeTrue()).help("enable ocl");
             parser.addArgument("-cdir").action(Arguments.storeTrue()).help("enable cdir");
+            parser.addArgument("-no-time").action(Arguments.storeFalse()).help("do not add timestamp to xcodeml");
             parsedArgs = parser.parseArgs(args);
         } catch (HelpScreenException hse)
         {
@@ -155,6 +157,7 @@ public class CLIOptions
         print_opts = parsedArgs.getBoolean("print_opts");
         ocl_enabled = parsedArgs.getBoolean("ocl");
         cdir_enabled = parsedArgs.getBoolean("cdir");
+        add_timestamp_enabled = parsedArgs.getBoolean("no_time");
     }
 
     static Path getOptionalPath(Namespace parsedArgs, Path workingDir, String name)
@@ -364,5 +367,10 @@ public class CLIOptions
     public Boolean getPrint_opts()
     {
         return print_opts;
+    }
+
+    public Boolean addTimestamp_enabled()
+    {
+        return add_timestamp_enabled;
     }
 }

--- a/F-FrontEnd-jni/src/java/xcodeml/f/util/FxCompiler.java
+++ b/F-FrontEnd-jni/src/java/xcodeml/f/util/FxCompiler.java
@@ -3,12 +3,125 @@
  */
 package xcodeml.f.util;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import xcodeml.f.util.NativeUtils.IOCache;
+import xcodeml.f.util.NativeUtils.IOCacheOutputEntry;
+
 public class FxCompiler
 {
-    static native int execute(CLIOptions opts) throws Exception;
+
+    static native int execute(CLIOptions opts, IOCache filesCache) throws Exception;
+
+    public static void checkCLIArgs(final CLIOptions opts) throws Exception
+    {
+        if (opts.native_in_mem_mode_enabled)
+        {
+            if (!opts.inc_dir_paths.isEmpty())
+            {
+                throw new Exception("Include directories not allowed in the in-memory mode");
+            }
+            if (!opts.xmod_inc_dir_paths.isEmpty())
+            {
+                throw new Exception("Xmod include directories not allowed in the in-memory mode");
+            }
+        }
+    }
+
+    static Path readStdinIntoFile() throws IOException
+    {
+        ByteArrayOutputStream stdin = new ByteArrayOutputStream();
+        {
+            byte[] buf = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = System.in.read(buf)) > 0)
+            {
+                stdin.write(buf, 0, bytesRead);
+            }
+        }
+        final Path path = Files.createTempFile("stdin", null);
+        try (RandomAccessFile raf = new RandomAccessFile(path.toFile(), "rw"))
+        {
+            FileChannel fileChannel = raf.getChannel();
+            final byte[] data = stdin.toByteArray();
+            MappedByteBuffer buf = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, data.length);
+            buf.put(data);
+        }
+        return path;
+    }
+
+    static IOCache createCache(CLIOptions opts) throws IOException
+    {
+        final IOCache filesCache = new IOCache(false);
+        if (opts.src_file_path != null)
+        {
+            filesCache.addInputFile(opts.src_file_path);
+        } else
+        {
+            filesCache.addInputFile(readStdinIntoFile(), "stdin");
+        }
+        if (opts.stdout_file_path != null)
+        {
+            filesCache.addOutputFile(opts.stdout_file_path, "stdout");
+        } else
+        {
+            filesCache.addOutputFile(Files.createTempFile("stdout", null), "stdout");
+        }
+        if (opts.out_file_path != null)
+        {
+            filesCache.addOutputFile(opts.out_file_path);
+        }
+        for (Path xmodPath : opts.xmod_inc_paths)
+        {
+            filesCache.addInputFile(xmodPath, xmodPath.getFileName().toString());
+        }
+        return filesCache;
+    }
+
+    static void printBuffer(MappedByteBuffer in, final int size, PrintStream out)
+    {
+        byte[] buf = new byte[4 * 1024];
+        for (int pos = 0; pos < size;)
+        {
+            final int len = Math.min(size - pos, buf.length);
+            in.get(buf, 0, len);
+            pos += len;
+            out.write(buf, 0, len);
+        }
+    }
+
+    static void updateCache(IOCache cache, CLIOptions opts)
+    {
+        for (IOCacheOutputEntry entry : cache.getOutputFiles())
+        {
+            switch (entry.filename)
+            {
+            case "stdout":
+                if (opts.stdout_file_path == null)
+                {
+                    printBuffer(entry.data, entry.getSize(), System.out);
+                    continue;
+                }
+                break;
+            default:
+                break;
+            }
+            // Apparently data will be written to disk anyway, force() just makes the call
+            // explicit
+            if (opts.fsync_enabled)
+            {
+                entry.data.force();
+            }
+        }
+    }
 
     public static void main(String[] args) throws Exception
     {
@@ -16,8 +129,20 @@ public class FxCompiler
         CLIOptions opts = CLIOptions.parseCmdlineArguments(args, WORKING_DIR);
         if (opts != null)
         {
+            checkCLIArgs(opts);
             System.loadLibrary("ffront-jni");
-            System.exit(execute(opts));
+            if (opts.native_in_mem_mode_enabled)
+            {
+                try (IOCache filesCache = createCache(opts))
+                {
+                    final int retCode = execute(opts, filesCache);
+                    updateCache(filesCache, opts);
+                    System.exit(retCode);
+                }
+            } else
+            {
+                System.exit(execute(opts, null));
+            }
         } else
         {
             System.exit(0);

--- a/F-FrontEnd-jni/src/java/xcodeml/f/util/FxCompiler.java
+++ b/F-FrontEnd-jni/src/java/xcodeml/f/util/FxCompiler.java
@@ -1,0 +1,26 @@
+/*
+ * @author Mikhail Zhigun
+ */
+package xcodeml.f.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class FxCompiler
+{
+    static native int execute(CLIOptions opts) throws Exception;
+
+    public static void main(String[] args) throws Exception
+    {
+        final Path WORKING_DIR = Paths.get(System.getProperty("user.dir"));
+        CLIOptions opts = CLIOptions.parseCmdlineArguments(args, WORKING_DIR);
+        if (opts != null)
+        {
+            System.loadLibrary("ffront-jni");
+            System.exit(execute(opts));
+        } else
+        {
+            System.exit(0);
+        }
+    }
+}

--- a/F-FrontEnd-jni/src/java/xcodeml/f/util/NativeUtils.java
+++ b/F-FrontEnd-jni/src/java/xcodeml/f/util/NativeUtils.java
@@ -1,0 +1,30 @@
+/*
+ * @author Mikhail Zhigun
+ */
+package xcodeml.f.util;
+
+public class NativeUtils
+{
+    public static class CppException extends Exception
+    {
+        public CppException(String msg)
+        {
+            super(msg);
+        }
+    }
+
+    public static class Pointer
+    {
+        public long getAddress()
+        {
+            return address;
+        }
+
+        public final long address;
+
+        public Pointer(long address)
+        {
+            this.address = address;
+        }
+    }
+}

--- a/F-FrontEnd-jni/src/java/xcodeml/f/util/NativeUtils.java
+++ b/F-FrontEnd-jni/src/java/xcodeml/f/util/NativeUtils.java
@@ -3,6 +3,17 @@
  */
 package xcodeml.f.util;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class NativeUtils
 {
     public static class CppException extends Exception
@@ -26,5 +37,128 @@ public class NativeUtils
         {
             this.address = address;
         }
+    }
+
+    static class IOCacheInputEntry
+    {
+        public IOCacheInputEntry(RandomAccessFile file, MappedByteBuffer data, String filename, int size)
+        {
+            this.file = file;
+            this.data = data;
+            this.filename = filename;
+            this.size = size;
+        }
+
+        public final RandomAccessFile file;
+        public final MappedByteBuffer data;
+        public final String filename;
+        public final int size;
+    }
+
+    static class IOCacheOutputEntry
+    {
+        public IOCacheOutputEntry(RandomAccessFile file, String filename)
+        {
+            this.file = file;
+            this.data = null;
+            this.filename = filename;
+            this.size = 0;
+        }
+
+        public int getSize()
+        {
+            return size;
+        }
+
+        public MappedByteBuffer getData()
+        {
+            return data;
+        }
+
+        public void allocateData(int size) throws IOException
+        {
+            FileChannel fileChannel = file.getChannel();
+            data = fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, size);
+            this.size = size;
+        }
+
+        public final RandomAccessFile file;
+        MappedByteBuffer data;
+        public final String filename;
+        int size;
+    }
+
+    public static class IOCache implements AutoCloseable
+    {
+        public IOCache(boolean flushFilesToDisk)
+        {
+            this.flushFilesToDisk = flushFilesToDisk;
+            inputFiles = new HashMap<Path, IOCacheInputEntry>();
+            outputFiles = new HashMap<Path, IOCacheOutputEntry>();
+        }
+
+        public void addInputFile(Path path) throws IOException
+        {
+            addInputFile(path, path.toString());
+        }
+
+        public void addInputFile(Path path, String filename) throws IOException
+        {
+            if (!inputFiles.containsKey(path))
+            {
+                File f = path.toFile();
+                RandomAccessFile raf = new RandomAccessFile(f, "r");
+                FileChannel fileChannel = raf.getChannel();
+                final int size = (int) fileChannel.size();
+                MappedByteBuffer buf = fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, size);
+                inputFiles.put(path, new NativeUtils.IOCacheInputEntry(raf, buf, filename, size));
+            }
+        }
+
+        public void addOutputFile(Path path) throws IOException
+        {
+            addOutputFile(path, path.toString());
+        }
+
+        public void addOutputFile(Path path, String filename) throws IOException
+        {
+            if (!outputFiles.containsKey(path))
+            {
+                File f = path.toFile();
+                RandomAccessFile raf = new RandomAccessFile(f, "rw");
+                outputFiles.put(path, new NativeUtils.IOCacheOutputEntry(raf, filename));
+            }
+        }
+
+        public List<IOCacheInputEntry> getInputFiles()
+        {
+            return new ArrayList<NativeUtils.IOCacheInputEntry>(inputFiles.values());
+        }
+
+        public List<IOCacheOutputEntry> getOutputFiles()
+        {
+            return new ArrayList<NativeUtils.IOCacheOutputEntry>(outputFiles.values());
+        }
+
+        @Override
+        public void close() throws Exception
+        {
+            for (IOCacheInputEntry e : inputFiles.values())
+            {
+                e.file.close();
+            }
+            for (IOCacheOutputEntry e : outputFiles.values())
+            {
+                if (flushFilesToDisk)
+                {
+                    e.data.force();
+                }
+                e.file.close();
+            }
+        }
+
+        final boolean flushFilesToDisk;
+        final Map<Path, IOCacheInputEntry> inputFiles;
+        final Map<Path, IOCacheOutputEntry> outputFiles;
     }
 }

--- a/F-FrontEnd/src/CMakeLists.txt
+++ b/F-FrontEnd/src/CMakeLists.txt
@@ -32,7 +32,6 @@ add_custom_command(OUTPUT "${C_EXPRCODE_C}"
 
 add_custom_target(generate_ffront_src DEPENDS "${C_EXPRCODE_H}" "${C_EXPRCODE_C}")
 
-
 set(F95_PARSER_C "${CMAKE_CURRENT_BINARY_DIR}/F95-parser.c")
 set(F95_PARSER_BISON_REPORT "${CMAKE_CURRENT_BINARY_DIR}/F95-parser-report.txt")
 
@@ -83,18 +82,12 @@ set_target_properties(ffront-cpp-shared
 target_link_libraries(ffront-cpp-shared ${LIBXML2_LIBRARY})
 target_include_directories(ffront-cpp-shared PUBLIC ${FFRONT_INC_DIRS})
 target_compile_definitions(ffront-cpp-shared PRIVATE ${FFRONT_DEFINES})
-if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"))
-  # Make shared object runnable
-  target_compile_options(ffront-cpp-shared PUBLIC "-pie")
-  target_link_libraries(ffront-cpp-shared "-pie -Wl,-E")
-endif()
 
-add_executable(ffront-cpp EXCLUDE_FROM_ALL ${FFRONT_CPP_SRC} ${BISON_F95_parser_OUTPUT_HEADER})
-add_dependencies(ffront-cpp generate_ffront_src create_int_install_dirs)
+add_executable(ffront-cpp EXCLUDE_FROM_ALL "${CMAKE_CURRENT_SOURCE_DIR}/F-driver.c")
+add_dependencies(ffront-cpp ffront-cpp-shared)
 set_target_properties(ffront-cpp
                       PROPERTIES
                       RUNTIME_OUTPUT_DIRECTORY ${INT_OMNI_HOME_BIN}
                       OUTPUT_NAME ffront-cpp)
-target_link_libraries(ffront-cpp ${LIBXML2_LIBRARY})
-target_include_directories(ffront-cpp PRIVATE ${FFRONT_INC_DIRS})
-target_compile_definitions(ffront-cpp PRIVATE ${FFRONT_DEFINES})
+target_link_libraries(ffront-cpp ffront-cpp-shared "-Wl,-rpath,'$ORIGIN/../share'")
+

--- a/F-FrontEnd/src/CMakeLists.txt
+++ b/F-FrontEnd/src/CMakeLists.txt
@@ -74,6 +74,21 @@ foreach(C_FILEPATH ${ffront_SRC} ${C_EXPRCODE_C} ${F95_PARSER_C})
                   @ONLY)
 endforeach()
 
+add_library(ffront-cpp-shared SHARED EXCLUDE_FROM_ALL ${FFRONT_CPP_SRC} ${BISON_F95_parser_OUTPUT_HEADER})
+add_dependencies(ffront-cpp-shared generate_ffront_src create_int_install_dirs)
+set_target_properties(ffront-cpp-shared
+                      PROPERTIES
+                      LIBRARY_OUTPUT_DIRECTORY ${INT_OMNI_HOME_SHARE}
+                      OUTPUT_NAME ffront-cpp)
+target_link_libraries(ffront-cpp-shared ${LIBXML2_LIBRARY})
+target_include_directories(ffront-cpp-shared PUBLIC ${FFRONT_INC_DIRS})
+target_compile_definitions(ffront-cpp-shared PRIVATE ${FFRONT_DEFINES})
+if(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"))
+  # Make shared object runnable
+  target_compile_options(ffront-cpp-shared PUBLIC "-pie")
+  target_link_libraries(ffront-cpp-shared "-pie -Wl,-E")
+endif()
+
 add_executable(ffront-cpp EXCLUDE_FROM_ALL ${FFRONT_CPP_SRC} ${BISON_F95_parser_OUTPUT_HEADER})
 add_dependencies(ffront-cpp generate_ffront_src create_int_install_dirs)
 set_target_properties(ffront-cpp

--- a/F-FrontEnd/src/F-compile-decl.c
+++ b/F-FrontEnd/src/F-compile-decl.c
@@ -599,12 +599,9 @@ void declare_procedure(enum name_class cls, expr name, TYPE_DESC type,
                 /*
                  * Copy the type of the current procedure.
                  */
-                tp = new_type_desc();
-                *tp = *type;
+                tp = clone_type_shallow(type);
                 TYPE_ATTR_FLAGS(tp) = 0;
-                FUNCTION_TYPE_RETURN_TYPE(tp) = new_type_desc();
-                *FUNCTION_TYPE_RETURN_TYPE(tp) =
-                    *FUNCTION_TYPE_RETURN_TYPE(type);
+                FUNCTION_TYPE_RETURN_TYPE(tp) = clone_type_shallow(FUNCTION_TYPE_RETURN_TYPE(type));
             }
             declare_id_type(id, tp);
 
@@ -829,14 +826,6 @@ static void declare_dummy_args(expr l, enum name_class cls)
             }
         }
     }
-}
-
-TYPE_DESC
-copy_type_shallow(TYPE_DESC tp)
-{
-    TYPE_DESC ret = new_type_desc();
-    *ret = *tp;
-    return ret;
 }
 
 static void copy_parent_type(ID id)
@@ -5250,7 +5239,7 @@ static TYPE_DESC type_apply_type_parameter0(TYPE_DESC tp, ID type_params)
     } else if (TYPE_KIND(tp)) {
         v = expv_apply_type_parameter(TYPE_KIND(tp), type_params);
         if (v != TYPE_KIND(tp)) {
-            tp = copy_type_shallow(tp);
+            tp = clone_type_shallow(tp);
             TYPE_KIND(tp) = v;
             while (TYPE_REF(tp) && TYPE_KIND(TYPE_REF(tp))) {
                 TYPE_REF(tp) = TYPE_REF(TYPE_REF(tp));
@@ -5260,7 +5249,7 @@ static TYPE_DESC type_apply_type_parameter0(TYPE_DESC tp, ID type_params)
     } else if (TYPE_LENG(tp)) {
         v = expv_apply_type_parameter(TYPE_LENG(tp), type_params);
         if (v != TYPE_LENG(tp)) {
-            tp = copy_type_shallow(tp);
+            tp = clone_type_shallow(tp);
             TYPE_LENG(tp) = v;
             while (TYPE_REF(tp) && TYPE_KIND(TYPE_REF(tp))) {
                 TYPE_REF(tp) = TYPE_REF(TYPE_REF(tp));
@@ -5270,7 +5259,7 @@ static TYPE_DESC type_apply_type_parameter0(TYPE_DESC tp, ID type_params)
     } else if (TYPE_REF(tp)) {
         tq = type_apply_type_parameter0(TYPE_REF(tp), type_params);
         if (tq != TYPE_REF(tp)) {
-            tp = copy_type_shallow(tp);
+            tp = clone_type_shallow(tp);
             TYPE_REF(tp) = tq;
         }
     }
@@ -5323,7 +5312,7 @@ type_apply_type_parameter(TYPE_DESC tp, expv type_param_values)
 
     type_param_values = compiled_type_param_values;
 
-    tq = copy_type_shallow(tp);
+    tq = clone_type_shallow(tp);
 
     if (TYPE_PARENT(tq)) {
         /*

--- a/F-FrontEnd/src/F-compile-expr.c
+++ b/F-FrontEnd/src/F-compile-expr.c
@@ -915,8 +915,7 @@ expv compile_expression(expr x)
                     TYPE_SET_NOT_FIXED(tp);
                 } else if (IS_ARRAY_TYPE(tp)) {
                     TYPE_DESC tq;
-                    TYPE_DESC new_tp = new_type_desc();
-                    *new_tp = *bottom_type(tp);
+                    TYPE_DESC new_tp = clone_type_shallow(bottom_type(tp));
                     tq = tp;
                     while (IS_ARRAY_TYPE(tq)) {
                         if (!IS_ARRAY_TYPE(TYPE_REF(tq)))
@@ -926,8 +925,7 @@ expv compile_expression(expr x)
                     TYPE_REF(tq) = new_tp;
                     TYPE_SET_NOT_FIXED(new_tp);
                 } else {
-                    TYPE_DESC new_tp = new_type_desc();
-                    *new_tp = *tp;
+                    TYPE_DESC new_tp = clone_type_shallow(tp);
                     tp = new_tp;
                     TYPE_SET_NOT_FIXED(tp);
                 }

--- a/F-FrontEnd/src/F-compile.c
+++ b/F-FrontEnd/src/F-compile.c
@@ -2668,8 +2668,7 @@ static void end_declaration()
             if (ep != NULL && EXT_PROC_TYPE(ep) != NULL) {
                 /* Copy type to avoid modifying TYPE_ATTR_FLAGS */
                 if (TYPE_IS_EXTERNAL(ip)) {
-                    tp = new_type_desc();
-                    *tp = *EXT_PROC_TYPE(ep);
+                    tp = clone_type_shallow(EXT_PROC_TYPE(ep));
                 } else {
                     tp = EXT_PROC_TYPE(ep);
                 }
@@ -5435,12 +5434,8 @@ static int type_is_replica(const TYPE_DESC tp)
  */
 static TYPE_DESC shallow_copy_type_for_module_id(TYPE_DESC original)
 {
-    TYPE_DESC new_tp;
-
-    new_tp = new_type_desc();
+    TYPE_DESC new_tp = clone_type_shallow(original);
     assert(new_tp != NULL);
-
-    *new_tp = *original;
 
     /* PUBLIC/PRIVATE attribute may be given by the module user */
     TYPE_UNSET_PUBLIC(new_tp);
@@ -8140,8 +8135,7 @@ accept:
                     int extattrs = TYPE_EXTATTR_FLAGS(vPteTyp);
 
                     *vPteTyp = *ftp;
-                    tp = new_type_desc();
-                    *tp = *FUNCTION_TYPE_RETURN_TYPE(vPteTyp);
+                    tp = clone_type_shallow(FUNCTION_TYPE_RETURN_TYPE(vPteTyp));
                     FUNCTION_TYPE_RETURN_TYPE(vPteTyp) = tp;
                     TYPE_ATTR_FLAGS(vPteTyp) =
                         attrs & !(TYPE_ATTR_PUBLIC | TYPE_ATTR_PRIVATE);
@@ -9463,8 +9457,7 @@ static expv compile_forall_header(expr x)
                 } else if (!IS_INT(ID_TYPE(id))) {
                     error("%s is not integer", SYM_NAME(sym));
                 }
-                tp = new_type_desc();
-                *tp = *ID_TYPE(id);
+                tp = clone_type_shallow(ID_TYPE(id));
                 id = declare_ident(sym, CL_VAR);
             } else {
                 id = declare_ident(sym, CL_VAR);

--- a/F-FrontEnd/src/F-datatype.c
+++ b/F-FrontEnd/src/F-datatype.c
@@ -2467,8 +2467,7 @@ copy_type_partially(TYPE_DESC tp, int doCopyAttr)
 {
     TYPE_DESC ret = NULL;
     if (tp != NULL) {
-        ret = new_type_desc();
-        *ret = *tp;
+        ret = clone_type_shallow(tp);
         if (doCopyAttr == FALSE) {
             TYPE_ATTR_FLAGS(ret) = 0;
             TYPE_EXTATTR_FLAGS(ret) = 0;
@@ -2477,5 +2476,12 @@ copy_type_partially(TYPE_DESC tp, int doCopyAttr)
             TYPE_REF(ret) = copy_type_partially(TYPE_REF(tp), doCopyAttr);
         }
     }
+    return ret;
+}
+
+TYPE_DESC clone_type_shallow(TYPE_DESC tp)
+{
+    TYPE_DESC ret = new_type_desc();
+    *ret = *tp;
     return ret;
 }

--- a/F-FrontEnd/src/F-datatype.h
+++ b/F-FrontEnd/src/F-datatype.h
@@ -13,6 +13,7 @@
 
 #include "C-expr.h"
 #include <stdint.h>
+#include <stddef.h>
 
 /* f77 data types */
 typedef enum datatype {
@@ -516,11 +517,11 @@ extern TYPE_DESC basic_type_desc[];
 #define IS_STRUCT_TYPE(tp) ((tp) != NULL && TYPE_BASIC_TYPE(tp) == TYPE_STRUCT)
 #define IS_ARRAY_TYPE(tp) ((tp) != NULL && TYPE_BASIC_TYPE(tp) == TYPE_ARRAY)
 #define IS_ELEMENT_TYPE(tp) ((tp) != NULL && (tp)->ref == NULL)
-#define IS_FUNCTION_TYPE(tp)                                                   \
-    ((tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_FUNCTION))
-#define IS_SUBR(tp) ((tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_SUBR))
+static inline bool IS_FUNCTION_TYPE(TYPE_DESC tp)
+{ return (tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_FUNCTION); }
+static inline bool IS_SUBR(TYPE_DESC tp) { return (tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_SUBR); }
 #define IS_VOID(tp) ((tp) != NULL && (TYPE_BASIC_TYPE(tp) == TYPE_VOID))
-#define IS_PROCEDURE_TYPE(tp) (IS_FUNCTION_TYPE(tp) || IS_SUBR(tp))
+static inline bool IS_PROCEDURE_TYPE(TYPE_DESC tp) { return IS_FUNCTION_TYPE(tp) || IS_SUBR(tp); }
 #define IS_PROCEDURE_POINTER(tp)                                               \
     ((tp) != NULL && IS_PROCEDURE_TYPE(tp) && TYPE_REF(tp) != NULL)
 #define IS_GENERIC_PROCEDURE_TYPE(tp)                                          \
@@ -674,5 +675,7 @@ extern TYPE_DESC basic_type_desc[];
 #define FUNCTION_TYPE_IS_INTERFACE(tp) ((tp)->proc_info.is_interface == TRUE)
 #define FUNCTION_TYPE_SET_INTERFACE(tp) ((tp)->proc_info.is_interface = TRUE)
 #define FUNCTION_TYPE_UNSET_INTERFACE(tp) ((tp)->proc_info.is_interface = FALSE)
+
+TYPE_DESC clone_type_shallow(TYPE_DESC tp);
 
 #endif /* _F_DATATYPE_H_ */

--- a/F-FrontEnd/src/F-driver.c
+++ b/F-FrontEnd/src/F-driver.c
@@ -1,0 +1,15 @@
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+int execute_args(int argc, char *argv[]);
+
+#if defined(__cplusplus)
+}
+#endif
+
+int main(int argc, char *argv[])
+{
+    execute_args(argc, argv);
+}

--- a/F-FrontEnd/src/F-front-context.c
+++ b/F-FrontEnd/src/F-front-context.c
@@ -27,6 +27,7 @@ void init_ffront_context(ffront_context* ctx)
     ctx->num_errors = 0;
     ctx->current_module_name = NULL;
     ctx->current_line = NULL;
+    init_out_xcodeml_context(&ctx->out_xcodeml_ctx);
 }
 
 void free_ffront_context(ffront_context* ctx)
@@ -36,6 +37,7 @@ void free_ffront_context(ffront_context* ctx)
     release_str_stream(&ctx->src_output);
     release_str_stream(&ctx->diag_output);
     release_str_stream(&ctx->debug_output);
+    free_out_xcodeml_context(&ctx->out_xcodeml_ctx);
 }
 
 THREAD_LOCAL ffront_context* ctx;
@@ -43,4 +45,5 @@ THREAD_LOCAL ffront_context* ctx;
 void set_ffront_context(ffront_context* in_ctx)
 {
     ctx = in_ctx;
+    set_out_xcodeml_context(&ctx->out_xcodeml_ctx);
 }

--- a/F-FrontEnd/src/F-front-context.c
+++ b/F-FrontEnd/src/F-front-context.c
@@ -22,12 +22,12 @@ void init_ffront_context(ffront_context* ctx)
     ctx->src_file_path = sdsempty();
     init_str_stream(&ctx->src_input);
     init_str_stream(&ctx->src_output);
-    init_str_stream(&ctx->diag_output);
     init_str_stream(&ctx->debug_output);
     ctx->num_errors = 0;
     ctx->current_module_name = NULL;
     ctx->current_line = NULL;
     init_out_xcodeml_context(&ctx->out_xcodeml_ctx);
+    ctx->files_cache = NULL;
 }
 
 void free_ffront_context(ffront_context* ctx)
@@ -35,12 +35,11 @@ void free_ffront_context(ffront_context* ctx)
     sdsfree(ctx->src_file_path);
     release_str_stream(&ctx->src_input);
     release_str_stream(&ctx->src_output);
-    release_str_stream(&ctx->diag_output);
     release_str_stream(&ctx->debug_output);
     free_out_xcodeml_context(&ctx->out_xcodeml_ctx);
 }
 
-THREAD_LOCAL ffront_context* ctx;
+ffront_context* ctx;
 
 void set_ffront_context(ffront_context* in_ctx)
 {

--- a/F-FrontEnd/src/F-front-context.h
+++ b/F-FrontEnd/src/F-front-context.h
@@ -36,6 +36,7 @@ typedef struct {
     bool cdir_enabled;
     bool pgi_enabled;
     bool module_cache_enabled;
+    bool add_timestamp_enabled;
 } ffront_params;
 
 struct symbol;
@@ -127,5 +128,6 @@ static inline bool ocl_enabled() { return ctx->params->ocl_enabled; }
 static inline bool cdir_enabled() { return ctx->params->cdir_enabled; }
 static inline bool pgi_enabled() { return ctx->params->pgi_enabled; }
 static inline bool module_cache_enabled() { return ctx->params->module_cache_enabled; }
+static inline bool add_timestamp_enabled() { return ctx->params->add_timestamp_enabled; }
 
 #endif //_F_FRONT_CONTEXT_H_

--- a/F-FrontEnd/src/F-front-context.h
+++ b/F-FrontEnd/src/F-front-context.h
@@ -3,6 +3,7 @@
 
 #include "F-output-xcodeml-context.h"
 #include "F-datatype.h"
+#include "io_cache.h"
 #include "bool.h"
 #include "utils.h"
 #include "c_vector/vector.h"
@@ -53,14 +54,14 @@ typedef struct {
     str_stream src_input;
     str_stream src_output;
     unsigned num_errors;
-    str_stream diag_output;
     str_stream debug_output;
     SYMBOL current_module_name;
     lineno_info* current_line;
     out_xcodeml_context out_xcodeml_ctx;
+    io_cache files_cache;
 } ffront_context;
 
-extern THREAD_LOCAL ffront_context* ctx;
+extern ffront_context* ctx;
 
 void init_ffront_params(ffront_params* params);
 void free_ffront_params(ffront_params* params);
@@ -76,7 +77,7 @@ static inline FILE* src_output() {
     return ctx->src_output.handle;
 }
 static inline FILE* diag_output() {
-    return ctx->diag_output.handle;
+    return ctx->debug_output.handle;
 }
 static inline FILE* debug_output() {
     return ctx->debug_output.handle;

--- a/F-FrontEnd/src/F-front-context.h
+++ b/F-FrontEnd/src/F-front-context.h
@@ -1,6 +1,7 @@
 #ifndef _F_FRONT_CONTEXT_H_
 #define _F_FRONT_CONTEXT_H_
 
+#include "F-output-xcodeml-context.h"
 #include "F-datatype.h"
 #include "bool.h"
 #include "utils.h"
@@ -55,6 +56,7 @@ typedef struct {
     str_stream debug_output;
     SYMBOL current_module_name;
     lineno_info* current_line;
+    out_xcodeml_context out_xcodeml_ctx;
 } ffront_context;
 
 extern THREAD_LOCAL ffront_context* ctx;

--- a/F-FrontEnd/src/F-front.h
+++ b/F-FrontEnd/src/F-front.h
@@ -33,10 +33,6 @@
 #define TRUE 1
 #define FALSE 0
 
-#ifdef SIMPLE_TYPE
-extern int Addr2Uint(void *x);
-#define ADDRX_PRINT_FMT "%d"
-#else /* SIMPLE_TYPE */
 #define Addr2Uint(X) ((uintptr_t)(X))
 
 #if __WORDSIZE == 64
@@ -44,7 +40,6 @@ extern int Addr2Uint(void *x);
 #else
 #define ADDRX_PRINT_FMT "%x"
 #endif
-#endif /* SIMPLE_TYPE */
 
 /*
  * Safe for the case if iter(p) (i.e. ID_NEXT(ip), EXT_ID_NEXT(ep)) is

--- a/F-FrontEnd/src/F-input-xmod.c
+++ b/F-FrontEnd/src/F-input-xmod.c
@@ -1265,8 +1265,7 @@ static int input_indexRange(xmlTextReaderPtr reader, HashTable *ht,
         return FALSE;
 
     bottom = tp;
-    base = new_type_desc();
-    *base = *bottom;
+    base = clone_type_shallow(bottom);
     TYPE_BASIC_TYPE(bottom) = TYPE_ARRAY;
     TYPE_REF(bottom) = base;
     TYPE_N_DIM(bottom) = TYPE_N_DIM(base) + 1;
@@ -1664,7 +1663,7 @@ static int input_FbasicType(xmlTextReaderPtr reader, HashTable *ht)
     TYPE_ENTRY baseTep;
     TYPE_ENTRY refTep;
     char *typeId = NULL;
-    char *ref;
+    char *ref = NULL;
     int isEmpty;
 
     if (!xmlMatchNode(reader, XML_READER_TYPE_ELEMENT, "FbasicType"))

--- a/F-FrontEnd/src/F-input-xmod.c
+++ b/F-FrontEnd/src/F-input-xmod.c
@@ -3286,25 +3286,25 @@ static int input_FfunctionDecl(xmlTextReaderPtr reader, HashTable *ht,
 
 static enum interface_info_class to_interface_info_class(int val)
 {
-	switch(val)
-	{
-	case INTF_ASSIGNMENT: return INTF_ASSIGNMENT;
-	case INTF_OPERATOR: return INTF_OPERATOR;
-	case INTF_USEROP: return INTF_USEROP;
-	case INTF_GENERICS: return INTF_GENERICS;
-	case INTF_GENERIC_FUNC: return INTF_GENERIC_FUNC;
-	case INTF_GENERIC_SUBR: return INTF_GENERIC_SUBR;
-	case INTF_GENERIC_WRITE_FORMATTED: return INTF_GENERIC_WRITE_FORMATTED;
-	case INTF_GENERIC_WRITE_UNFORMATTED: return INTF_GENERIC_WRITE_UNFORMATTED;
-	case INTF_GENERIC_READ_FORMATTED: return INTF_GENERIC_READ_FORMATTED;
-	case INTF_GENERIC_READ_UNFORMATTED: return INTF_GENERIC_READ_UNFORMATTED;
-	case INTF_ABSTRACT: return INTF_ABSTRACT;
-	case INTF_DECL : return INTF_DECL;
-	default:
-		fatal("unexepected value");
-		//Unreachable code
-		return INTF_ASSIGNMENT;
-	};
+    switch(val)
+    {
+    case INTF_ASSIGNMENT: return INTF_ASSIGNMENT;
+    case INTF_OPERATOR: return INTF_OPERATOR;
+    case INTF_USEROP: return INTF_USEROP;
+    case INTF_GENERICS: return INTF_GENERICS;
+    case INTF_GENERIC_FUNC: return INTF_GENERIC_FUNC;
+    case INTF_GENERIC_SUBR: return INTF_GENERIC_SUBR;
+    case INTF_GENERIC_WRITE_FORMATTED: return INTF_GENERIC_WRITE_FORMATTED;
+    case INTF_GENERIC_WRITE_UNFORMATTED: return INTF_GENERIC_WRITE_UNFORMATTED;
+    case INTF_GENERIC_READ_FORMATTED: return INTF_GENERIC_READ_FORMATTED;
+    case INTF_GENERIC_READ_UNFORMATTED: return INTF_GENERIC_READ_UNFORMATTED;
+    case INTF_ABSTRACT: return INTF_ABSTRACT;
+    case INTF_DECL : return INTF_DECL;
+    default:
+        fatal("unexepected value");
+        //Unreachable code
+        return INTF_ASSIGNMENT;
+    };
 
 }
 
@@ -3352,10 +3352,10 @@ static int input_FinterfaceDecl(xmlTextReaderPtr reader, HashTable *ht,
 
       id = find_ident_head(find_symbol(name), id_list);
       if (ID_CLASS(id) == CL_TAGNAME) { /* for multi class */
-	id = find_ident_head(ID_SYM(id), ID_NEXT(id));
+    id = find_ident_head(ID_SYM(id), ID_NEXT(id));
       } else if (ID_CLASS(id) == CL_MULTI) {
-	id = multi_find_class(id, CL_PROC);
-	PROC_CLASS(id) = P_UNDEFINEDPROC;
+    id = multi_find_class(id, CL_PROC);
+    PROC_CLASS(id) = P_UNDEFINEDPROC;
       }
 
       interface_class = INTF_GENERICS;
@@ -3369,10 +3369,10 @@ static int input_FinterfaceDecl(xmlTextReaderPtr reader, HashTable *ht,
       
       id = find_ident_head(find_symbol(name), id_list);
       if (ID_CLASS(id) == CL_TAGNAME) { /* for multi class */
-	id = find_ident_head(ID_SYM(id), ID_NEXT(id));
+    id = find_ident_head(ID_SYM(id), ID_NEXT(id));
       } else if (ID_CLASS(id) == CL_MULTI) {
-	id = multi_find_class(id, CL_PROC);
-	PROC_CLASS(id) = P_UNDEFINEDPROC;
+    id = multi_find_class(id, CL_PROC);
+    PROC_CLASS(id) = P_UNDEFINEDPROC;
       }
 
       interface_class = INTF_OPERATOR;
@@ -3711,8 +3711,19 @@ int input_intermediate_file(const SYMBOL mod_name, const SYMBOL submod_name,
                  SYM_NAME(submod_name), extension);
     }
 
-    search_include_path(filename, &filepath);
-    reader = xmlNewTextReaderFilename(filepath);
+    {
+        void* startAddress = NULL;
+        size_t size = 0;
+        if(ctx->files_cache && io_cache_get_input_file_as_mem(ctx->files_cache, filename, &startAddress, &size))
+        {
+            reader = xmlReaderForMemory((const char *) startAddress, size, NULL, NULL, 0);
+        }
+        else
+        {
+            search_include_path(filename, &filepath);
+            reader = xmlNewTextReaderFilename(filepath);
+        }
+    }
 
 #if defined(_FC_IS_GFORTRAN) || defined(_FC_IS_FRTPX)
     sds_string command = sdsempty();

--- a/F-FrontEnd/src/F-intrinsic.c
+++ b/F-FrontEnd/src/F-intrinsic.c
@@ -356,12 +356,10 @@ expv compile_intrinsic_call0(ID id, expv args, int ignoreTypeMismatch)
         }
 
         if (IS_VOID(tp)) {
-            TYPE_DESC ret = new_type_desc();
-            *ret = *tp;
+            TYPE_DESC ret = clone_type_shallow(tp);
             tp = intrinsic_subroutine_type();
         } else {
-            TYPE_DESC ret = new_type_desc();
-            *ret = *tp;
+            TYPE_DESC ret = clone_type_shallow(tp);
             tp = intrinsic_function_type(ret);
         }
 

--- a/F-FrontEnd/src/F-output-xcodeml-context.h
+++ b/F-FrontEnd/src/F-output-xcodeml-context.h
@@ -17,6 +17,9 @@ typedef struct type_ext_id {
 static const int type_desc_set = 33;
 KHASH_SET_INIT_INT64(type_desc_set);
 
+static const int type_to_idx_map = 34;
+KHASH_MAP_INIT_INT64(type_to_idx_map, uint64_t);
+
 struct s_out_xcodeml_context {
 	char s_timestamp[CEXPR_OPTVAL_CHARLEN];
     bool is_emitting_for_submodule;
@@ -32,6 +35,20 @@ struct s_out_xcodeml_context {
     FILE *print_fp;
     bool is_outputed_module;
     bool is_emitting_module;
+    const char* mod_name;
+    khash_t(type_to_idx_map) * t_to_idx;
+    uint64_t type_int_counter;
+    uint64_t type_char_counter;
+    uint64_t type_logical_counter;
+    uint64_t type_real_counter;
+    uint64_t type_complex_counter;
+    uint64_t type_func_counter;
+    uint64_t type_arr_counter;
+    uint64_t type_struct_counter;
+    uint64_t type_gnumeric_counter;
+    uint64_t type_generic_counter;
+    uint64_t type_namelist_counter;
+    uint64_t type_enum_counter;
 };
 
 typedef struct s_out_xcodeml_context out_xcodeml_context;

--- a/F-FrontEnd/src/F-output-xcodeml-context.h
+++ b/F-FrontEnd/src/F-output-xcodeml-context.h
@@ -1,0 +1,45 @@
+#ifndef _F_OUTPUT_XCODEML_CONTEXT_H_
+#define _F_OUTPUT_XCODEML_CONTEXT_H_
+
+#include "F-datatype.h"
+#include "F-ident.h"
+#include "utils.h"
+#include "external/klib/khash.h"
+
+#define CURRENT_FUNCTION_STACK_MAX_SIZE 100
+#define CEXPR_OPTVAL_CHARLEN 128
+
+typedef struct type_ext_id {
+    EXT_ID ep;
+    struct type_ext_id *next;
+} * TYPE_EXT_ID;
+
+static const int type_desc_set = 33;
+KHASH_SET_INIT_INT64(type_desc_set);
+
+struct s_out_xcodeml_context {
+	char s_timestamp[CEXPR_OPTVAL_CHARLEN];
+    bool is_emitting_for_submodule;
+    bool is_inside_interface;
+    EXT_ID current_function_stack[CURRENT_FUNCTION_STACK_MAX_SIZE];
+    int current_function_top;
+    // Set containing int representation of type descriptor addresses
+    khash_t(type_desc_set) * type_set;
+    khash_t(type_desc_set) * tbp_set;
+    TYPE_DESC type_list, type_list_tail;
+    TYPE_DESC tbp_list, tbp_list_tail;
+    TYPE_EXT_ID type_ext_id_list, type_ext_id_last;
+    FILE *print_fp;
+    bool is_outputed_module;
+    bool is_emitting_module;
+};
+
+typedef struct s_out_xcodeml_context out_xcodeml_context;
+
+void init_out_xcodeml_context(out_xcodeml_context*);
+void free_out_xcodeml_context(out_xcodeml_context*);
+void set_out_xcodeml_context(out_xcodeml_context*);
+
+extern THREAD_LOCAL out_xcodeml_context* outx_ctx;
+
+#endif /* _F_OUTPUT_XCODEML_CONTEXT_H_ */

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -6762,7 +6762,7 @@ void output_XcodeML_file()
             "              compiler-info=\"%s\"\n"
             "              version=\"%s\">\n",
             s,
-            F_TARGET_LANG, getTimestamp(), F_FRONTEND_NAME, F_FRONTEND_VER);
+            F_TARGET_LANG, add_timestamp_enabled() ? getTimestamp() : "", F_FRONTEND_NAME, F_FRONTEND_VER);
         sdsfree(s);
     }
 

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -6996,9 +6996,11 @@ int output_module_file(struct module *mod, const char *filename)
     if (module_compile_enabled()) {
         outx_ctx->print_fp = src_output();
     } else {
-        if ((outx_ctx->print_fp = fopen(filename, "w")) == NULL) {
+        if(!(ctx->files_cache && (outx_ctx->print_fp = io_cache_get_output_file(ctx->files_cache, filename)))) {
+            if ((outx_ctx->print_fp = fopen(filename, "w")) == NULL) {
             fatal("couldn't open module file to write: %s", filename);
             return FALSE;
+            }
         }
     }
 

--- a/F-FrontEnd/src/F-output-xcodeml.c
+++ b/F-FrontEnd/src/F-output-xcodeml.c
@@ -5,12 +5,10 @@
 #include "F-front.h"
 #include "F-front-context.h"
 #include "F-output-xcodeml.h"
+#include "F-output-xcodeml-context.h"
 #include "module-manager.h"
 #include <limits.h>
-#include "external/klib/khash.h"
 #include "omni_errors.h"
-
-#define CHAR_BUF_SIZE 65536
 
 #define ARRAY_LEN(a) (sizeof(a) / sizeof(a[0]))
 
@@ -32,9 +30,6 @@ int Addr2Uint(void *x)
 }
 #endif
 
-int is_emitting_for_submodule;
-int is_inside_interface = FALSE;
-
 static void outx_expv(int l, expv v);
 static void outx_functionDefinition(int l, EXT_ID ep);
 static void outx_function_as_interfaceDecl(int l, EXT_ID ep);
@@ -50,20 +45,15 @@ static int id_is_visibleVar(ID id);
 static int id_is_visibleVar_for_symbols(ID id);
 static void mark_type_desc_in_id_list(ID ids);
 
-char s_timestamp[CEXPR_OPTVAL_CHARLEN] = {0};
-char s_xmlIndent[CEXPR_OPTVAL_CHARLEN] = "  ";
-
-#define CURRENT_FUNCTION_STACK_MAX_SIZE MAX_UNIT_CTL_CONTAINS + 100
+static const char* s_XML_INDENT = "  ";
 
 static const size_t current_function_stack_max_size = CURRENT_FUNCTION_STACK_MAX_SIZE;
-EXT_ID current_function_stack[CURRENT_FUNCTION_STACK_MAX_SIZE];
-int current_function_top = 0;
 
 static inline EXT_ID GET_CRT_FUNCEP()
 {
-    if(current_function_top >= 0 && current_function_top < current_function_stack_max_size)
+    if(outx_ctx->current_function_top >= 0 && outx_ctx->current_function_top < current_function_stack_max_size)
     {
-        return current_function_stack[current_function_top];
+        return outx_ctx->current_function_stack[outx_ctx->current_function_top];
     }
     else
     {
@@ -74,9 +64,9 @@ static inline EXT_ID GET_CRT_FUNCEP()
 
 static inline void SET_CRT_FUNCEP(EXT_ID ep)
 {
-    if(current_function_top >= 0 && current_function_top < current_function_stack_max_size)
+    if(outx_ctx->current_function_top >= 0 && outx_ctx->current_function_top < current_function_stack_max_size)
     {
-        current_function_stack[current_function_top] = ep;
+    	outx_ctx->current_function_stack[outx_ctx->current_function_top] = ep;
     }
     else
     {
@@ -86,10 +76,10 @@ static inline void SET_CRT_FUNCEP(EXT_ID ep)
 
 static inline void CRT_FUNCEP_PUSH(EXT_ID ep)
 {
-    current_function_top++;
-    if(current_function_top < current_function_stack_max_size)
+    outx_ctx->current_function_top++;
+    if(outx_ctx->current_function_top < current_function_stack_max_size)
     {
-        current_function_stack[current_function_top] = (ep);
+    	outx_ctx->current_function_stack[outx_ctx->current_function_top] = (ep);
     }
     else
     {
@@ -99,17 +89,12 @@ static inline void CRT_FUNCEP_PUSH(EXT_ID ep)
 
 static inline void CRT_FUNCEP_POP()
 {
-    if(current_function_top == 0)
+    if(outx_ctx->current_function_top == 0)
     {
         fatal("current_function_stack is already empty");
     }
-    current_function_top--;
+    outx_ctx->current_function_top--;
 }
-
-typedef struct type_ext_id {
-    EXT_ID ep;
-    struct type_ext_id *next;
-} * TYPE_EXT_ID;
 
 #define FOREACH_TYPE_EXT_ID(te, headte)                                        \
     for ((te) = (headte); (te) != NULL; (te) = (te)->next)
@@ -123,38 +108,22 @@ typedef struct type_ext_id {
         (tail) = (te);                                                         \
     }
 
-// Set containing int representation of type descriptor addresses
-const int type_desc_set = 33;
-KHASH_SET_INIT_INT64(type_desc_set);
-khash_t(type_desc_set) * type_set;
-khash_t(type_desc_set) * tbp_set;
-
-static TYPE_DESC type_list, type_list_tail;
-static TYPE_DESC tbp_list, tbp_list_tail;
-static TYPE_EXT_ID type_module_proc_list, type_module_proc_last;
-static TYPE_EXT_ID type_ext_id_list, type_ext_id_last;
-static FILE *print_fp;
-static char s_charBuf[CHAR_BUF_SIZE];
-static int is_outputed_module = FALSE;
-
 #define GET_EXT_LINE(ep)                                                       \
     (EXT_LINE(ep)                                                              \
          ? EXT_LINE(ep)                                                        \
          : EXT_PROC_ID_LIST(ep) ? ID_LINE(EXT_PROC_ID_LIST(ep)) : NULL)
-
-static int is_emitting_module = FALSE;
 
 /**
  * @brief Initialize sets.
  */
 static void init_sets()
 {
-    if (type_set == NULL) {
-        type_set = kh_init(type_desc_set);
+    if (outx_ctx->type_set == NULL) {
+        outx_ctx->type_set = kh_init(type_desc_set);
     }
 
-    if (tbp_set == NULL) {
-        tbp_set = kh_init(type_desc_set);
+    if (outx_ctx->tbp_set == NULL) {
+        outx_ctx->tbp_set = kh_init(type_desc_set);
     }
 }
 
@@ -163,19 +132,19 @@ static void init_sets()
  */
 static void reset_sets()
 {
-    if (tbp_set != NULL && kh_size(tbp_set) > 0) {
-        kh_destroy(type_desc_set, tbp_set);
-        tbp_set = kh_init(type_desc_set);
+    if (outx_ctx->tbp_set != NULL && kh_size(outx_ctx->tbp_set) > 0) {
+        kh_destroy(type_desc_set, outx_ctx->tbp_set);
+        outx_ctx->tbp_set = kh_init(type_desc_set);
     }
-    if (type_set != NULL && kh_size(type_set) > 0) {
-        kh_destroy(type_desc_set, type_set);
-        type_set = kh_init(type_desc_set);
+    if (outx_ctx->type_set != NULL && kh_size(outx_ctx->type_set) > 0) {
+        kh_destroy(type_desc_set, outx_ctx->type_set);
+        outx_ctx->type_set = kh_init(type_desc_set);
     }
 }
 
-static void set_module_emission_mode(int mode) { is_emitting_module = mode; }
+static void set_module_emission_mode(bool mode) { outx_ctx->is_emitting_module = mode; }
 
-int is_emitting_xmod(void) { return is_emitting_module; }
+bool is_emitting_xmod(void) { return outx_ctx->is_emitting_module; }
 
 static const char *xtag(enum expr_code code)
 {
@@ -602,7 +571,7 @@ static void outx_indent(int l)
 {
     int i;
     for (i = 0; i < l; ++i)
-        fputs(s_xmlIndent, print_fp);
+        fputs(s_XML_INDENT, outx_ctx->print_fp);
 }
 
 static void outx_printi(int l, const char *fmt, ...)
@@ -610,25 +579,27 @@ static void outx_printi(int l, const char *fmt, ...)
     outx_indent(l);
     va_list args;
     va_start(args, fmt);
-    vfprintf(print_fp, fmt, args);
+    vfprintf(outx_ctx->print_fp, fmt, args);
     va_end(args);
 }
 
 #define outx_print(...) outx_printi(0, __VA_ARGS__)
 
-static void outx_puts(const char *s) { fputs(s, print_fp); }
+static void outx_puts(const char *s) { fputs(s, outx_ctx->print_fp); }
 
 /**
  * output any tag with format
  */
 static void outx_tag(int l, const char *tagAndFmt, ...)
 {
-    sprintf(s_charBuf, "<%s>\n", tagAndFmt);
+    sds_string s_charBuf = sdsempty();
+    s_charBuf = sdscatprintf(s_charBuf, "<%s>\n", tagAndFmt);
     outx_indent(l);
     va_list args;
     va_start(args, tagAndFmt);
-    vfprintf(print_fp, s_charBuf, args);
+    vfprintf(outx_ctx->print_fp, s_charBuf, args);
     va_end(args);
+    sdsfree(s_charBuf);
 }
 
 /**
@@ -648,70 +619,63 @@ static void xstrcat(char **p, const char *s)
     *p += len;
 }
 
-static const char *getXmlEscapedStr(const char *s)
+static void getXmlEscapedStr(const char *s, sds_string* px)
 {
-    static char x[CHAR_BUF_SIZE];
     const char *p = s;
-    char *px = x;
     char c;
-    x[0] = '\0';
+    set_sds_string(px, "");
 
     while ((c = *p++)) {
         switch (c) {
             case '<':
-                xstrcat(&px, "&lt;");
+                *px = sdscat(*px, "&lt;");
                 break;
             case '>':
-                xstrcat(&px, "&gt;");
+                *px = sdscat(*px, "&gt;");
                 break;
             case '&':
-                xstrcat(&px, "&amp;");
+                *px = sdscat(*px, "&amp;");
                 break;
             case '"':
-                xstrcat(&px, "&quot;");
+                *px = sdscat(*px, "&quot;");
                 break;
             case '\'':
-                xstrcat(&px, "&apos;");
+                *px = sdscat(*px, "&apos;");
                 break;
             /* \002 used as quote in F95-lexer.c */
             case '\002':
-                xstrcat(&px, "&quot;");
+                *px = sdscat(*px, "&quot;");
                 break;
             case '\a':
-                xstrcat(&px, "\\a");
+                *px = sdscat(*px, "\\a");
                 break; // alert
             case '\f':
-                xstrcat(&px, "\\f");
+                *px = sdscat(*px, "\\f");
                 break; // formfeed
             case '\r':
-                xstrcat(&px, "\\r");
+                *px = sdscat(*px, "\\r");
                 break; // carriage return
             case '\n':
-                xstrcat(&px, "\\n");
+                *px = sdscat(*px, "\\n");
                 break; // new line
             case '\t':
-                xstrcat(&px, "\\t");
+                *px = sdscat(*px, "\\t");
                 break; // horizontal tab
             case '\b':
-                xstrcat(&px, "\\b");
+                *px = sdscat(*px, "\\b");
                 break; // backspace
             case '\v':
-                xstrcat(&px, "\\v");
+                *px = sdscat(*px, "\\v");
                 break; // vertical tab
             default:
                 if ((c >= 0 && c <= 0x1F) || c == 0x7F) {
-                    char buf[16];
-                    sprintf(buf, "&#%x;", (unsigned int)(c & 0xFF));
-                    xstrcat(&px, buf);
+                    *px = sdscatprintf(*px, "&#%x;", (unsigned int)(c & 0xFF));
                 } else {
-                    *px++ = c;
+                    *px = sdscatlen(*px, &c, 1);
                 }
                 break;
         }
     }
-    *px = 0;
-
-    return x;
 }
 
 /**
@@ -739,8 +703,8 @@ static void outx_intAsConst(int l, omllint_t n)
  * Check the string has quote character(s) or not.
  * @param str a string.
  * @return STR_HAS_NO_QUOTE: no quote character contained.
- *	<br/> STR_HAS_DBL_QUOTE: contains at least a double quote.
- *	<br/> STR_HAS_SGL_QUOTE: contains at least a single quote.
+ *    <br/> STR_HAS_DBL_QUOTE: contains at least a double quote.
+ *    <br/> STR_HAS_SGL_QUOTE: contains at least a single quote.
  */
 static int hasStringQuote(const char *str)
 {
@@ -754,13 +718,11 @@ static int hasStringQuote(const char *str)
     }
 }
 
-static const char *getRawString(expv v)
+static void getRawString(expv v, sds_string* res)
 {
-    static char buf[CHAR_BUF_SIZE];
-
     switch (EXPV_CODE(v)) {
         case INT_CONSTANT:
-            snprintf(buf, CHAR_BUF_SIZE, OMLL_DFMT, EXPV_INT_VALUE(v));
+            *res = sdscatprintf(*res, OMLL_DFMT, EXPV_INT_VALUE(v));
             break;
         case STRING_CONSTANT: {
             if (EXPV_STR(v) != NULL) {
@@ -768,13 +730,17 @@ static const char *getRawString(expv v)
                 switch (quote) {
                     case STR_HAS_SGL_QUOTE:
                     case STR_HAS_NO_QUOTE: {
-                        snprintf(buf, CHAR_BUF_SIZE, "&quot;%s&quot;",
-                                 getXmlEscapedStr(EXPV_STR(v)));
+                        sds_string s = sdsempty();
+                        getXmlEscapedStr(EXPV_STR(v), &s);
+                        *res = sdscatprintf(*res, "&quot;%s&quot;", s);
+                        sdsfree(s);
                         break;
                     }
                     case STR_HAS_DBL_QUOTE: {
-                        snprintf(buf, CHAR_BUF_SIZE, "&#39;%s&#39;",
-                                 getXmlEscapedStr(EXPV_STR(v)));
+                        sds_string s = sdsempty();
+                        getXmlEscapedStr(EXPV_STR(v), &s);
+                        *res = sdscatprintf(*res, "&#39;%s&#39;", s);
+                        sdsfree(s);
                         break;
                     }
                     default: {
@@ -783,7 +749,7 @@ static const char *getRawString(expv v)
                     }
                 }
             } else {
-                snprintf(buf, CHAR_BUF_SIZE, "\"\"");
+                *res = sdscatprintf(*res, "\"\"");
             }
             break;
         }
@@ -792,29 +758,33 @@ static const char *getRawString(expv v)
         case F_PARAM:
         case F_FUNC:
         case F95_USER_DEFINED:
-            snprintf(buf, CHAR_BUF_SIZE, "%s",
-                     getXmlEscapedStr(SYM_NAME(EXPV_NAME(v))));
+            {
+                sds_string s = sdsempty();
+                getXmlEscapedStr(SYM_NAME(EXPV_NAME(v)), &s);
+                *res = sdscatprintf(*res, "%s", s);
+                sdsfree(s);
+            }
             break;
         case ARRAY_REF:
-            snprintf(buf, CHAR_BUF_SIZE, "%s",
-                     getXmlEscapedStr(SYM_NAME(EXPV_NAME(EXPR_ARG1(v)))));
+            {
+                sds_string s = sdsempty();
+                getXmlEscapedStr(SYM_NAME(EXPV_NAME(EXPR_ARG1(v))), &s);
+                *res = sdscatprintf(*res, "%s", s);
+                sdsfree(s);
+            }
             break;
         case F_CONCAT_EXPR: {
-            char buf1[CHAR_BUF_SIZE], buf2[CHAR_BUF_SIZE];
-            strncpy(buf1, getRawString(EXPR_ARG1(v)), CHAR_BUF_SIZE);
-            strncpy(buf2, getRawString(EXPR_ARG2(v)), CHAR_BUF_SIZE);
-            int ret = snprintf(buf, CHAR_BUF_SIZE, "%s // %s", buf1, buf2);
-            if(ret < 0)
-            {
-            	fatal("Output truncated");
-            }
+            sds_string buf1 = sdsempty(), buf2 = sdsempty();
+            getRawString(EXPR_ARG1(v), &buf1);
+            getRawString(EXPR_ARG2(v), &buf2);
+            *res = sdscatprintf(*res, "%s // %s", buf1, buf2);
+            sdsfree(buf1);
+            sdsfree(buf2);
             break;
         }
         default:
             FATAL_ERROR();
     }
-
-    return buf;
 }
 
 static void outx_true(int cond, const char *flagname)
@@ -934,12 +904,10 @@ static const char *getBasicTypeID(BASIC_DATA_TYPE t)
 /**
  * get typeID
  */
-static const char *getTypeID(TYPE_DESC tp)
+void getTypeID(TYPE_DESC tp, sds_string* res)
 {
-    static char buf[256];
-
     if (checkBasic(tp) && checkBasic(TYPE_REF(tp))) {
-        strcpy(buf, getBasicTypeID(TYPE_BASIC_TYPE(tp)));
+        *res = sdscpy(*res, getBasicTypeID(TYPE_BASIC_TYPE(tp)));
     } else {
         char pfx;
 
@@ -989,10 +957,8 @@ static const char *getTypeID(TYPE_DESC tp)
                 FATAL_ERROR();
         }
 
-        sprintf(buf, "%c" ADDRX_PRINT_FMT, pfx, Addr2Uint(tp));
+        *res = sdscatprintf(*res, "%c" ADDRX_PRINT_FMT, pfx, Addr2Uint(tp));
     }
-
-    return buf;
 }
 
 /**
@@ -1009,7 +975,10 @@ static void outx_typeAttrs(int l, TYPE_DESC tp, const char *tag, int options)
     if (TYPE_IS_NOT_FIXED(tp) && TYPE_BASIC_TYPE(tp) == TYPE_UNKNOWN) {
         outx_printi(l, "<%s type=\"%s\"", tag, "FnumericAll");
     } else {
-        outx_printi(l, "<%s type=\"%s\"", tag, getTypeID(tp));
+        sds_string type_id = sdsempty();
+        getTypeID(tp, &type_id);
+        outx_printi(l, "<%s type=\"%s\"", tag, type_id);
+        sdsfree(type_id);
     }
     if (IS_STRUCT_TYPE(tp) && tp->imported_id) {
         outx_print(" imported_id=\"%s\"", tp->imported_id);
@@ -1046,7 +1015,11 @@ static void outx_typeAttrs(int l, TYPE_DESC tp, const char *tag, int options)
         outx_true(TYPE_IS_CONTIGUOUS(tp), "is_contiguous");
 
         if (TYPE_PARENT(tp)) {
-            outx_print(" extends=\"%s\"", getTypeID(TYPE_PARENT_TYPE(tp)));
+
+            sds_string type_id = sdsempty();
+            getTypeID(TYPE_PARENT_TYPE(tp), &type_id);
+            outx_print(" extends=\"%s\"", type_id);
+            sdsfree(type_id);
         }
         outx_true(TYPE_IS_CLASS(tp), "is_class");
         outx_true(TYPE_IS_ASSUMED(tp), "is_assumed");
@@ -1087,8 +1060,10 @@ static void outx_typeAttrs(int l, TYPE_DESC tp, const char *tag, int options)
 
 static void outx_typeAttrOnly_functionType(int l, TYPE_DESC tp, const char *tag)
 {
-    const char *tid = getTypeID(tp);
-    outx_printi(l, "<%s type=\"%s\"", tag, tid);
+    sds_string type_id = sdsempty();
+    getTypeID(tp, &type_id);
+    outx_printi(l, "<%s type=\"%s\"", tag, type_id);
+    sdsfree(type_id);
 }
 
 static void outx_lineno(lineno_info *li)
@@ -1097,7 +1072,12 @@ static void outx_lineno(lineno_info *li)
         outx_print(" lineno=\"%d\"", li->ln_no);
         if (li->end_ln_no)
             outx_print(" endlineno=\"%d\"", li->end_ln_no);
-        outx_print(" file=\"%s\"", getXmlEscapedStr(FILE_NAME(li->file_id)));
+        {
+            sds_string s = sdsempty();
+            getXmlEscapedStr(FILE_NAME(li->file_id), &s);
+            outx_print(" file=\"%s\"", s);
+            sdsfree(s);
+        }
     }
 }
 
@@ -1107,21 +1087,19 @@ static void outx_lineno(lineno_info *li)
 static void outx_vtagLineno(int l, const char *tag, lineno_info *li,
                             va_list args)
 {
-    static char buf1[CHAR_BUF_SIZE], buf2[CHAR_BUF_SIZE];
-    int ret = snprintf(buf1, sizeof(buf1), "<%s", tag);
-    if(ret < 0)
-    {
-    	fatal("Output truncated");
-    }
+    sds_string buf1 = sdsempty(), buf2 = sdsempty();
+    buf1 = sdscatprintf(buf1, "<%s", tag);
     if (args != NULL) {
-        vsnprintf(buf2, sizeof(buf2), buf1, args);
+        buf2 = sdscatvprintf(buf2, buf1, args);
     } else {
-        strncpy(buf2, buf1, sizeof(buf2));
+        buf2 = sdscpy(buf2, buf1);
     }
 
     outx_indent(l);
     outx_puts(buf2);
     outx_lineno(li);
+    sdsfree(buf1);
+    sdsfree(buf2);
 }
 
 static void outx_tagOfStatement(int l, expv v)
@@ -1132,12 +1110,14 @@ static void outx_tagOfStatement(int l, expv v)
 
 static void outx_tagOfStatement1(int l, expv v, const char *attrs, ...)
 {
-    sprintf(s_charBuf, "%s%s", XTAG(v), attrs ? attrs : "");
+    sds_string s_charBuf = sdsempty();
+    s_charBuf = sdscatprintf(s_charBuf, "%s%s", XTAG(v), attrs ? attrs : "");
     va_list args;
     va_start(args, attrs);
     outx_vtagLineno(l, s_charBuf, EXPR_LINE(v), args);
     va_end(args);
     outx_puts(">\n");
+    sdsfree(s_charBuf);
 }
 
 static void outx_tagOfStatement2(int l, expv v)
@@ -1158,27 +1138,33 @@ static void outx_tagOfStatement3(int l, const char *tag, lineno_info *li)
 static void outx_tagOfStatementWithConstructName(int l, expv v, expv cv,
                                                  int hasChild)
 {
+    sds_string s_charBuf = sdsempty();
     if (cv)
-        sprintf(s_charBuf, "%s construct_name=\"%s\"", XTAG(v),
+    {
+        s_charBuf = sdscatprintf(s_charBuf, "%s construct_name=\"%s\"", XTAG(v),
                 SYM_NAME(EXPV_NAME(cv)));
+    }
     else
-        strcpy(s_charBuf, XTAG(v));
+        s_charBuf = sdscpy(s_charBuf, XTAG(v));
 
     outx_vtagLineno(l, s_charBuf, EXPR_LINE(v), NULL);
     if (hasChild)
         outx_puts(">\n");
     else
         outx_puts("/>\n");
+    sdsfree(s_charBuf);
 }
 
 static void outx_tagOfStatementNoChild(int l, expv v, const char *attrs, ...)
 {
-    sprintf(s_charBuf, "%s%s", XTAG(v), attrs ? attrs : "");
+    sds_string s_charBuf = sdsempty();
+    s_charBuf = sdscatprintf(s_charBuf, "%s%s", XTAG(v), attrs ? attrs : "");
     va_list args;
     va_start(args, attrs);
     outx_vtagLineno(l, s_charBuf, EXPR_LINE(v), args);
     va_end(args);
     outx_puts("/>\n");
+    sdsfree(s_charBuf);
 }
 
 static void outx_vtagOfDecl(int l, const char *tag, lineno_info *li,
@@ -1226,8 +1212,14 @@ static void outx_tagText(int l, const char *tag, const char *s)
     outx_printi(l, "<%s>%s</%s>\n", tag, s, tag);
 }
 
-#define outx_symbolName(l, s)                                                  \
-    outx_tagText(l, "name", getXmlEscapedStr(SYM_NAME(s)))
+static void outx_symbolName(int l, const SYMBOL s)
+{
+    sds_string str = sdsempty();
+    getXmlEscapedStr(SYM_NAME(s), &str);
+    outx_tagText(l, "name", str);
+    sdsfree(str);
+}
+
 #define outx_expvName(l, v) outx_symbolName(l, EXPV_NAME(v))
 
 /**
@@ -1264,7 +1256,10 @@ static void outx_symbolNameWithFunctionType_EXT(int l, EXT_ID ep)
 static void outx_symbolNameWithType_ID(int l, ID id)
 {
     outx_typeAttrs(l, ID_TYPE(id), "name", TOPT_TYPEONLY);
-    outx_print(">%s</name>\n", getXmlEscapedStr(SYM_NAME(ID_SYM(id))));
+    sds_string s = sdsempty();
+    getXmlEscapedStr(SYM_NAME(ID_SYM(id)), &s);
+    outx_print(">%s</name>\n", s);
+    sdsfree(s);
 }
 
 /**
@@ -1272,7 +1267,10 @@ static void outx_symbolNameWithType_ID(int l, ID id)
  */
 static void outx_linenoNameWithFconstant(int l, expv fconst)
 {
-    outx_tagText(l, "name", getRawString(fconst));
+    sds_string s = sdsempty();
+    getRawString(fconst, &s);
+    outx_tagText(l, "name", s);
+    sdsfree(s);
 }
 
 /**
@@ -1901,7 +1899,12 @@ static void outx_typedArrayConstructor(int l, expv v)
     const int l1 = l + 1;
     EXPV_TYPE(v) = EXPV_TYPE(v);
     outx_typeAttrs(l, EXPV_TYPE(v), XTAG(v), TOPT_TYPEONLY);
-    outx_print(" element_type=\"%s\">\n", getTypeID(element_tp));
+    {
+        sds_string type_id = sdsempty();
+        getTypeID(element_tp, &type_id);
+        outx_print(" element_type=\"%s\">\n", type_id);
+        sdsfree(type_id);
+    }
     outx_expv(l1, EXPR_ARG1(v));
     outx_expvClose(l, v);
 }
@@ -1984,12 +1987,16 @@ static void outx_typeGuard(int l, expv v, int is_class)
         if (EXPR_ARG1(v) == NULL) { //
             outx_print(" kind=\"CLASS_DEFAULT\">\n");
         } else {
-            outx_print(" kind=\"CLASS_IS\" type=\"%s\">\n",
-                       getTypeID(EXPV_TYPE(EXPR_ARG1(v))));
+            sds_string type_id = sdsempty();
+            getTypeID(EXPV_TYPE(EXPR_ARG1(v)), &type_id);
+            outx_print(" kind=\"CLASS_IS\" type=\"%s\">\n", type_id);
+            sdsfree(type_id);
         }
     } else { // TYPE IS
-        outx_print(" kind=\"TYPE_IS\" type=\"%s\">\n",
-                   getTypeID(EXPV_TYPE(EXPR_ARG1(v))));
+        sds_string type_id = sdsempty();
+        getTypeID(EXPV_TYPE(EXPR_ARG1(v)), &type_id);
+        outx_print(" kind=\"TYPE_IS\" type=\"%s\">\n", type_id);
+        sdsfree(type_id);
     }
 
     outx_body(l1, EXPR_ARG2(v));
@@ -2102,7 +2109,10 @@ static void outx_importStatement(int l, expv v)
         FOR_ITEMS_IN_LIST (lp, ident_list) {
             arg = LIST_ITEM(lp);
             if (EXPR_CODE(arg) == IDENT) {
-                outx_printi(l1, "<name>%s</name>\n", getRawString(arg));
+                sds_string s = sdsempty();
+                getRawString(arg, &s);
+                outx_printi(l1, "<name>%s</name>\n", s);
+                sdsfree(s);
             }
         }
     }
@@ -2169,17 +2179,21 @@ static void outx_STOPPAUSE_statement_with_expression_code(int l, expv v)
  */
 static void outx_STOPPAUSE_statement(int l, expv v)
 {
-    char buf[CHAR_BUF_SIZE];
+    sds_string buf = sdsempty();
     expv v1 = EXPR_ARG1(v);
-    buf[0] = '\0';
 
     if (v1) {
         switch (EXPV_CODE(v1)) {
             case INT_CONSTANT:
-                sprintf(buf, " code=\"" OMLL_DFMT "\"", EXPV_INT_VALUE(v1));
+            	buf = sdscatprintf(buf, " code=\"" OMLL_DFMT "\"", EXPV_INT_VALUE(v1));
                 break;
             case STRING_CONSTANT:
-                sprintf(buf, " message=\"%s\"", getXmlEscapedStr(EXPV_STR(v1)));
+                {
+                	sds_string s = sdsempty();
+                    getXmlEscapedStr(EXPV_STR(v1), &s);
+                    buf = sdscatprintf(buf, " message=\"%s\"", s);
+                    sdsfree(s);
+                }
                 break;
             default:
                 return outx_STOPPAUSE_statement_with_expression_code(l, v);
@@ -2187,6 +2201,7 @@ static void outx_STOPPAUSE_statement(int l, expv v)
     }
 
     outx_tagOfStatementNoChild(l, v, buf);
+    sdsfree(buf);
 }
 
 /**
@@ -2197,19 +2212,15 @@ static void outx_EXITCYCLE_statement(int l, expv v)
     outx_tagOfStatementWithConstructName(l, v, EXPR_ARG1(v), 0);
 }
 
-static const char *getFormatID(expv v)
+static void getFormatID(expv v, sds_string* res)
 {
-    static char buf[CHAR_BUF_SIZE];
-
     if (v && EXPV_CODE(v) == LIST)
         v = EXPR_ARG1(v);
 
     if (v == NULL)
-        strcpy(buf, "*");
+        *res = sdscpy(*res, "*");
     else
-        strcpy(buf, getRawString(v));
-
-    return buf;
+        getRawString(v, res);
 }
 
 /**
@@ -2217,8 +2228,10 @@ static const char *getFormatID(expv v)
  */
 static void outx_formatDecl(int l, expv v)
 {
-    const char *fmt = getXmlEscapedStr(EXPV_STR(EXPV_LEFT(v)));
+    sds_string fmt = sdsempty();
+    getXmlEscapedStr(EXPV_STR(EXPV_LEFT(v)), &fmt);
     outx_tagOfDeclNoChild(l, "%s format=\"%s\"", EXPR_LINE(v), XTAG(v), fmt);
+    sdsfree(fmt);
 }
 
 /**
@@ -2264,8 +2277,10 @@ static void outx_printStatement(int l, expv v)
                 FATAL_ERROR();
                 break;
         }
-
-    outx_tagOfStatement1(l, v, " format=\"%s\"", getFormatID(format));
+    sds_string formatID = sdsempty();
+    getFormatID(format, &formatID);
+    outx_tagOfStatement1(l, v, " format=\"%s\"", formatID);
+    sdsfree(formatID);
     outx_valueList(l + 1, EXPR_ARG2(v));
     outx_expvClose(l, v);
 }
@@ -2624,24 +2639,20 @@ static void outx_ALLOCDEALLOC_statement(int l, expv v)
     expv vmold = expr_list_get_n(keywords, 1);
     expv vsource = expr_list_get_n(keywords, 2);
     expv verrmsg = expr_list_get_n(keywords, 3);
-    char type_buf[128];
-    char stat_buf[128];
+    {
+        sds_string type_buf = sdsempty();
 
-    const char *tid = NULL;
 
-    if (EXPV_TYPE(v)) {
-        tid = getTypeID(EXPV_TYPE(v));
-        sprintf(type_buf, " type=\"%s\"", tid);
-    } else {
-        type_buf[0] = '\0';
+        if (EXPV_TYPE(v)) {
+            sds_string tid = sdsempty();
+            getTypeID(EXPV_TYPE(v), &tid);
+            type_buf = sdscatprintf(type_buf, " type=\"%s\"", tid);
+            sdsfree(tid);
+        }
+
+        outx_tagOfStatement1(l, v, type_buf);
+        sdsfree(type_buf);
     }
-
-#if 0
-    /* Deprecated */
-    print_allocate_keyword(stat_buf, vstat, "stat_name");
-#endif
-
-    outx_tagOfStatement1(l, v, type_buf, stat_buf);
     outx_allocList(l1, EXPR_ARG1(v));
     if (vstat) {
         outx_printi(l1, "<allocOpt kind=\"stat\">\n");
@@ -2666,21 +2677,16 @@ static void outx_ALLOCDEALLOC_statement(int l, expv v)
     outx_expvClose(l, v);
 }
 
-static const char *getKindParameter(TYPE_DESC tp)
+void getKindParameter(TYPE_DESC tp, sds_string* res)
 {
-    static char buf[256];
     expv v = TYPE_KIND(tp);
 
     if (IS_DOUBLED_TYPE(tp)) {
-        sprintf(buf, "%d", KIND_PARAM_DOUBLE);
+        *res = sdscatprintf(*res, "%d", KIND_PARAM_DOUBLE);
     } else if (v && (EXPV_CODE(v) == INT_CONSTANT || EXPV_CODE(v) == IDENT ||
                      EXPV_CODE(v) == F_VAR || EXPV_CODE(v) == FLOAT_CONSTANT)) {
-        strcpy(buf, getRawString(v));
-    } else {
-        return NULL;
+        getRawString(v, res);
     }
-
-    return buf;
 }
 
 /**
@@ -2688,51 +2694,60 @@ static const char *getKindParameter(TYPE_DESC tp)
  */
 static void outx_constants(int l, expv v)
 {
-    static char buf[CHAR_BUF_SIZE];
+    sds_string buf = sdsempty();
     const int l1 = l + 1;
-    const char *tid;
+    sds_string tid = sdsempty();
     const char *tag = XTAG(v);
     TYPE_DESC tp = EXPV_TYPE(v);
-    const char *kind;
 
     switch (EXPV_CODE(v)) {
         case INT_CONSTANT:
             if (IS_LOGICAL(EXPV_TYPE(v))) {
-                sprintf(buf, ".%s.", EXPV_INT_VALUE(v) ? "TRUE" : "FALSE");
+                buf = sdscatprintf(buf, ".%s.", EXPV_INT_VALUE(v) ? "TRUE" : "FALSE");
                 tag = "FlogicalConstant";
             } else {
                 omllint_t n = EXPV_INT_VALUE(v);
-                sprintf(buf, OMLL_DFMT, n);
+                buf = sdscatprintf(buf, OMLL_DFMT, n);
             }
             if (tp == NULL)
                 tp = type_INT;
             // tid = getBasicTypeID(TYPE_BASIC_TYPE(tp));
-            tid = getTypeID(tp);
+            getTypeID(tp, &tid);
             goto print_constant;
 
         case FLOAT_CONSTANT:
             if (EXPV_ORIGINAL_TOKEN(v))
-                strcpy(buf, EXPV_ORIGINAL_TOKEN(v));
+                buf = sdscpy(buf, EXPV_ORIGINAL_TOKEN(v));
             else
-                sprintf(buf, "%Lf", EXPV_FLOAT_VALUE(v));
+                buf = sdscatprintf(buf, "%Lf", EXPV_FLOAT_VALUE(v));
             if (tp == NULL)
                 tp = type_REAL;
             // tid = getBasicTypeID(TYPE_BASIC_TYPE(tp));
-            tid = getTypeID(tp);
+            getTypeID(tp, &tid);
             goto print_constant;
 
         case STRING_CONSTANT:
-            strcpy(buf, getXmlEscapedStr(EXPV_STR(v)));
+            {
+                sds_string s = sdsempty();
+                getXmlEscapedStr(EXPV_STR(v), &s);
+                buf = sdscpy(buf, s);
+                sdsfree(s);
+            }
             assert(tp);
-            tid = getTypeID(tp);
+            getTypeID(tp, &tid);
             goto print_constant;
 
         print_constant:
             outx_printi(l, "<%s type=\"%s\"", tag, tid);
-            if ( // EXPV_CODE(v) != STRING_CONSTANT &&
-                (kind = getKindParameter(tp)) != NULL)
-                outx_print(" kind=\"%s\"", kind);
-            outx_print(">%s</%s>\n", buf, tag);
+            {
+                sds_string kind = sdsempty();
+                getKindParameter(tp, &kind);
+                if ( // EXPV_CODE(v) != STRING_CONSTANT &&
+                    sdslen(kind) != 0)
+                    outx_print(" kind=\"%s\"", kind);
+                outx_print(">%s</%s>\n", buf, tag);
+                sdsfree(kind);
+            }
             break;
 
         case COMPLEX_CONSTANT:
@@ -2746,6 +2761,8 @@ static void outx_constants(int l, expv v)
         default:
             FATAL_ERROR();
     }
+    sdsfree(buf);
+    sdsfree(tid);
 }
 
 /**
@@ -2755,7 +2772,12 @@ static void outx_pragmaStatement(int l, expv v)
 {
     list lp = EXPV_LIST(v);
     outx_tagOfStatement2(l, v);
-    outx_puts(getXmlEscapedStr(EXPV_STR(LIST_ITEM(lp))));
+    {
+        sds_string s = sdsempty();
+        getXmlEscapedStr(EXPV_STR(LIST_ITEM(lp)), &s);
+        outx_puts(s);
+        sdsfree(s);
+    }
     outx_expvClose(0, v);
 }
 
@@ -2766,7 +2788,12 @@ static void outx_commentLine(int l, expv v)
 {
     list lp = EXPV_LIST(v);
     outx_tagOfStatement2(l, v);
-    outx_puts(getXmlEscapedStr(EXPV_STR(LIST_ITEM(lp))));
+    {
+        sds_string s = sdsempty();
+        getXmlEscapedStr(EXPV_STR(LIST_ITEM(lp)), &s);
+        outx_puts(s);
+        sdsfree(s);
+    }
     outx_expvClose(0, v);
 }
 
@@ -3663,8 +3690,18 @@ static void outx_useRename(int l, expv x)
     if (EXPR_CODE(x) == F03_OPERATOR_RENAMING) {
         outx_true(TRUE, "is_operator");
     }
-    outx_printi(0, " local_name=\"%s\"", getRawString(local));
-    outx_printi(0, " use_name=\"%s\"/>\n", getRawString(use));
+    {
+        sds_string s = sdsempty();
+        getRawString(local, &s);
+        outx_printi(0, " local_name=\"%s\"", s);
+        sdsfree(s);
+    }
+    {
+        sds_string s = sdsempty();
+        getRawString(use, &s);
+        outx_printi(0, " use_name=\"%s\"/>\n", s);
+        sdsfree(s);
+    }
 }
 
 /**
@@ -3687,7 +3724,7 @@ static void outx_useDecl(int l, expv v, int is_intrinsic)
         outx_useRename(l + 1, x);
     }
 
-    include_module_file(print_fp, EXPV_NAME(EXPR_ARG1(v)));
+    include_module_file(outx_ctx->print_fp, EXPV_NAME(EXPR_ARG1(v)));
 
     outx_expvClose(l, v);
 }
@@ -3706,9 +3743,18 @@ static void outx_useRenamable(int l, int expr_code, expv local, expv use)
     }
 
     if (local != NULL)
-        outx_printi(0, " local_name=\"%s\"", getRawString(local));
-
-    outx_printi(0, " use_name=\"%s\"/>\n", getRawString(use));
+    {
+        sds_string s = sdsempty();
+        getRawString(local, &s);
+        outx_printi(0, " local_name=\"%s\"", s);
+        sdsfree(s);
+    }
+    {
+        sds_string s = sdsempty();
+        getRawString(use, &s);
+        outx_printi(0, " use_name=\"%s\"/>\n", s);
+        sdsfree(s);
+    }
 }
 
 /**
@@ -3731,7 +3777,7 @@ static void outx_useOnlyDecl(int l, expv v, int is_intrinsic)
         outx_useRenamable(l + 1, EXPR_CODE(x), EXPR_ARG1(x), EXPR_ARG2(x));
     }
 
-    include_module_file(print_fp, EXPV_NAME(EXPR_ARG1(v)));
+    include_module_file(outx_ctx->print_fp, EXPV_NAME(EXPR_ARG1(v)));
 
     outx_expvClose(l, v);
 }
@@ -3915,7 +3961,6 @@ static void outx_FORALL_statement(int l, expv v)
     expv init = EXPR_ARG1(EXPR_ARG1(v));
     expv mask = EXPR_ARG2(EXPR_ARG1(v));
     expv body = EXPR_ARG2(v);
-    const char *tid = NULL;
 
     outx_vtagLineno(l, XTAG(v), EXPR_LINE(v), NULL);
 
@@ -3923,8 +3968,10 @@ static void outx_FORALL_statement(int l, expv v)
         outx_print(" construct_name=\"%s\"", SYM_NAME(EXPR_SYM(EXPR_ARG4(v))));
     }
     if (EXPV_TYPE(init)) {
-        tid = getTypeID(EXPV_TYPE(init));
+        sds_string tid = sdsempty();
+        getTypeID(EXPV_TYPE(init), &tid);
         outx_print(" type=\"%s\"", tid);
+        sdsfree(tid);
     }
     outx_print(">\n");
 
@@ -3990,8 +4037,10 @@ static void outx_DOCONCURRENT_statement(int l, expv v)
         outx_print(" construct_name=\"%s\"", SYM_NAME(EXPR_SYM(EXPR_ARG3(v))));
     }
     if (EXPV_TYPE(EXPR_ARG1(v))) {
-        tid = getTypeID(EXPV_TYPE(EXPR_ARG1(v)));
+        sds_string tid = sdsempty();
+        getTypeID(EXPV_TYPE(EXPR_ARG1(v)), &tid);
         outx_print(" type=\"%s\"", tid);
+        sdsfree(tid);
     }
     outx_print(">\n");
 
@@ -4642,7 +4691,7 @@ static void mark_type_desc_skip_tbp(TYPE_DESC tp, int skip_tbp)
          */
         TYPE_LINK(tp) = NULL;
         TYPE_IS_REFERENCED(tp) = TRUE;
-        TYPE_LINK_ADD_WITH_SET(tp, tbp_list, tbp_list_tail, tbp_set);
+        TYPE_LINK_ADD_WITH_SET(tp, outx_ctx->tbp_list, outx_ctx->tbp_list_tail, outx_ctx->tbp_set);
         return;
     }
 
@@ -4668,7 +4717,7 @@ static void mark_type_desc_skip_tbp(TYPE_DESC tp, int skip_tbp)
     collect_type_desc(TYPE_DIM_LOWER(tp));
     collect_type_desc(TYPE_DIM_STEP(tp));
 
-    TYPE_LINK_ADD_WITH_SET(tp, type_list, type_list_tail, type_set);
+    TYPE_LINK_ADD_WITH_SET(tp, outx_ctx->type_list, outx_ctx->type_list_tail, outx_ctx->type_set);
     TYPE_IS_REFERENCED(tp) = TRUE;
 
     if (IS_PROCEDURE_TYPE(tp)) {
@@ -4701,17 +4750,17 @@ static void mark_type_desc(TYPE_DESC tp) { mark_type_desc_skip_tbp(tp, TRUE); }
 
 /*       if (TYPE_IS_COSHAPE(tp)){ */
 
-/* 	if (TYPE_IS_COSHAPE(TYPE_REF(tp))){ */
-/* 	  check_type_desc(TYPE_REF(tp)); */
-/* 	} */
-/* 	else { */
+/*     if (TYPE_IS_COSHAPE(TYPE_REF(tp))){ */
+/*       check_type_desc(TYPE_REF(tp)); */
+/*     } */
+/*     else { */
 
-/* 	  mark_type_desc(TYPE_REF(tp)); */
-/* 	} */
+/*       mark_type_desc(TYPE_REF(tp)); */
+/*     } */
 
 /*       } */
 /*       else { */
-/* 	mark_type_desc(array_element_type(tp)); */
+/*     mark_type_desc(array_element_type(tp)); */
 /*       } */
 
 /*     } */
@@ -4777,7 +4826,7 @@ void add_type_ext_id(EXT_ID ep)
     TYPE_EXT_ID te = XMALLOC(TYPE_EXT_ID, sizeof(struct type_ext_id));
     // bzero(te, sizeof(struct type_ext_id));
     te->ep = ep;
-    FUNC_EXT_LINK_ADD(te, type_ext_id_list, type_ext_id_last);
+    FUNC_EXT_LINK_ADD(te, outx_ctx->type_ext_id_list, outx_ctx->type_ext_id_last);
 }
 
 static void mark_type_desc_id(ID id)
@@ -4828,7 +4877,7 @@ static void mark_type_desc_in_id_list(ID ids)
 static void unmark_type_table()
 {
     TYPE_DESC tp;
-    for (tp = type_list; tp != NULL; tp = TYPE_LINK(tp)) {
+    for (tp = outx_ctx->type_list; tp != NULL; tp = TYPE_LINK(tp)) {
         if (tp == NULL || TYPE_IS_REFERENCED(tp) == FALSE || IS_MODULE(tp))
             continue;
         TYPE_IS_REFERENCED(tp) = FALSE;
@@ -4837,11 +4886,8 @@ static void unmark_type_table()
 
 static void outx_kind(int l, TYPE_DESC tp)
 {
-    static expv doubledKind = NULL;
+    expv doubledKind = expv_int_term(INT_CONSTANT, type_INT, KIND_PARAM_DOUBLE);
     expv vkind;
-
-    if (doubledKind == NULL)
-        doubledKind = expv_int_term(INT_CONSTANT, type_INT, KIND_PARAM_DOUBLE);
 
     if (IS_DOUBLED_TYPE(tp))
         vkind = doubledKind;
@@ -4851,6 +4897,7 @@ static void outx_kind(int l, TYPE_DESC tp)
         return;
 
     outx_childrenWithTag(l, "kind", vkind);
+    free(doubledKind);
 }
 
 /**
@@ -4946,15 +4993,22 @@ static void outx_basicTypeNoCharNoAry(int l, TYPE_DESC tp)
     assert(rtp);
     outx_typeAttrs(l, tp, "FbasicType", 0);
     if (TYPE_TYPE_PARAM_VALUES(tp) || tp->codims) {
-        outx_print(" ref=\"%s\">\n", getTypeID(rtp));
+        sds_string tid = sdsempty();
+        getTypeID(rtp, &tid);
+        outx_print(" ref=\"%s\">\n", tid);
+        sdsfree(tid);
         if (tp->codims)
             outx_coShape(l + 1, tp);
         if (TYPE_TYPE_PARAM_VALUES(tp)) {
             outx_typeParamValues(l + 1, TYPE_TYPE_PARAM_VALUES(tp));
         }
         outx_close(l, "FbasicType");
-    } else
-        outx_print(" ref=\"%s\"/>\n", getTypeID(rtp));
+    } else {
+        sds_string tid = sdsempty();
+        getTypeID(rtp, &tid);
+        outx_print(" ref=\"%s\"/>\n", tid);
+        sdsfree(tid);
+    }
 }
 
 /**
@@ -5003,7 +5057,11 @@ static void outx_arrayType(int l, TYPE_DESC tp)
     const int l1 = l + 1;
 
     outx_typeAttrs(l, tp, "FbasicType", 0);
-    outx_print(" ref=\"%s\">\n", getTypeID(array_element_type(tp)));
+
+    sds_string tid = sdsempty();
+    getTypeID(array_element_type(tp), &tid);
+    outx_print(" ref=\"%s\">\n", tid);
+    sdsfree(tid);
 
     outx_indexRangeOfType(l1, tp);
 
@@ -5046,7 +5104,10 @@ static void outx_functionType_procedure(int l, TYPE_DESC tp)
          * the procedure variable declared like "PROCEDURE(), POINTER :: p".
          * So don't emit this attribute.
          */
-        outx_print(" ref=\"%s\"/>\n", getTypeID(TYPE_REF(tp)));
+        sds_string tid = sdsempty();
+        getTypeID(TYPE_REF(tp), &tid);
+        outx_print(" ref=\"%s\"/>\n", tid);
+        sdsfree(tid);
     } else {
         outx_print("/>\n");
     }
@@ -5063,11 +5124,13 @@ static void outx_functionType(int l, TYPE_DESC tp)
 
     } else {
         const int l1 = l + 1, l2 = l1 + 1;
-        const char *rtid = NULL;
 
-        const char *tid = getTypeID(tp);
-
-        outx_printi(l, "<FfunctionType type=\"%s\"", tid);
+        {
+            sds_string tid = sdsempty();
+            getTypeID(tp, &tid);
+            outx_printi(l, "<FfunctionType type=\"%s\"", tid);
+            sdsfree(tid);
+        }
 
         if (FUNCTION_TYPE_RESULT(tp)) {
             outx_print(" result_name=\"%s\"",
@@ -5077,13 +5140,18 @@ static void outx_functionType(int l, TYPE_DESC tp)
         /* outx_typeAttrOnly_functionTypeWithResultVar(l, ep, "FfunctionType");
          */
 
-        if (FUNCTION_TYPE_RETURN_TYPE(tp)) {
-            rtid = getTypeID(FUNCTION_TYPE_RETURN_TYPE(tp));
-        } else {
-            rtid = "Fvoid";
+        {
+            sds_string rtid = sdsempty();
+            if (FUNCTION_TYPE_RETURN_TYPE(tp)) {
+                getTypeID(FUNCTION_TYPE_RETURN_TYPE(tp), &rtid);
+            } else {
+                rtid = sdscpy(rtid, "Fvoid");
+            }
+            outx_print(" return_type=\"%s\"", rtid);
+            sdsfree(rtid);
         }
 
-        outx_print(" return_type=\"%s\"", rtid);
+
         outx_true(FUNCTION_TYPE_IS_PROGRAM(tp), "is_program");
 
         if (FUNCTION_TYPE_IS_VISIBLE_INTRINSIC(tp)) {
@@ -5097,7 +5165,7 @@ static void outx_functionType(int l, TYPE_DESC tp)
 
         outx_false(TYPE_IS_IMPURE(tp), "is_pure");
 
-        if (is_emitting_for_submodule) {
+        if (outx_ctx->is_emitting_for_submodule) {
             /*
              * "is_defined" attribute is only for SUBMODULE
              */
@@ -5159,7 +5227,12 @@ static void outx_structType(int l, TYPE_DESC tp)
                 continue;
             }
             outx_printi(l2, "<typeParam ");
-            outx_print("type=\"%s\" ", getTypeID(ID_TYPE(id)));
+            {
+                sds_string tid = sdsempty();
+                getTypeID(ID_TYPE(id), &tid);
+                outx_print("type=\"%s\" ", tid);
+                sdsfree(tid);
+            }
             if (TYPE_IS_KIND(ID_TYPE(id))) {
                 outx_print("attr=\"kind\">\n");
             } else if (TYPE_IS_LEN(ID_TYPE(id))) {
@@ -5181,7 +5254,12 @@ static void outx_structType(int l, TYPE_DESC tp)
             has_type_bound_procedure = TRUE;
             continue;
         }
-        outx_printi(l2, "<id type=\"%s\">\n", getTypeID(ID_TYPE(id)));
+        {
+            sds_string tid = sdsempty();
+            getTypeID(ID_TYPE(id), &tid);
+            outx_printi(l2, "<id type=\"%s\">\n", tid);
+            sdsfree(tid);
+        }
         outx_symbolName(l3, ID_SYM(id));
         if (VAR_INIT_VALUE(id) != NULL) {
             outx_value(l3, VAR_INIT_VALUE(id));
@@ -5232,11 +5310,17 @@ static void outx_structType(int l, TYPE_DESC tp)
                 outx_true(TYPE_IS_PRIVATE(id), "is_private");
                 outx_printi(0, ">\n");
                 if (!is_defined_io) {
-                    outx_tagText(l3, "name", getXmlEscapedStr(SYM_NAME(ID_SYM(id))));
+                    sds_string s = sdsempty();
+                    getXmlEscapedStr(SYM_NAME(ID_SYM(id)), &s);
+                    outx_tagText(l3, "name", s);
+                    sdsfree(s);
                 }
                 outx_tag(l3, "binding");
                 FOREACH_ID (binding, TBP_BINDING(id)) {
-                    outx_tagText(l4, "name", getXmlEscapedStr(SYM_NAME(ID_SYM(binding))));
+                    sds_string s = sdsempty();
+                    getXmlEscapedStr(SYM_NAME(ID_SYM(binding)), &s);
+                    outx_tagText(l4, "name", s);
+                    sdsfree(s);
                 }
                 outx_close(l3, "binding");
                 outx_close(l2, "typeBoundGenericProcedure");
@@ -5250,7 +5334,12 @@ static void outx_structType(int l, TYPE_DESC tp)
                 }
             } else {
                 outx_printi(l2, "<typeBoundProcedure");
-                outx_printi(0, " type=\"%s\"", getTypeID(ID_TYPE(id)));
+                {
+                    sds_string tid = sdsempty();
+                    getTypeID(ID_TYPE(id), &tid);
+                    outx_printi(0, " type=\"%s\"", tid);
+                    sdsfree(tid);
+                }
 
                 if (TBP_BINDING_ATTRS(id) & TYPE_BOUND_PROCEDURE_PASS)
                     outx_printi(0, " pass=\"pass\"");
@@ -5271,9 +5360,21 @@ static void outx_structType(int l, TYPE_DESC tp)
 
                 outx_printi(0, ">\n");
 
-                outx_tagText(l3, "name", getXmlEscapedStr(SYM_NAME(ID_SYM(id))));
+                {
+                    sds_string s = sdsempty();
+                    getXmlEscapedStr(SYM_NAME(ID_SYM(id)), &s);
+                    outx_tagText(l3, "name", s);
+                    sdsfree(s);
+                }
+
                 outx_tag(l3, "binding");
-                outx_tagText(l4, "name", getXmlEscapedStr(SYM_NAME(ID_SYM(TBP_BINDING(id)))));
+
+                {
+                    sds_string s = sdsempty();
+                    getXmlEscapedStr(SYM_NAME(ID_SYM(TBP_BINDING(id))), &s);
+                    outx_tagText(l4, "name", s);
+                    sdsfree(s);
+                }
                 outx_close(l3, "binding");
 
                 outx_close(l2, "typeBoundProcedure");
@@ -5373,7 +5474,7 @@ static int id_is_visibleVar(ID id)
         if (TYPE_IS_MODIFIED(tp)) {
             return TRUE;
         }
-        if ((is_outputed_module && GET_CRT_FUNCEP() == NULL) &&
+        if ((outx_ctx->is_outputed_module && GET_CRT_FUNCEP() == NULL) &&
             (TYPE_IS_PUBLIC(tp) || TYPE_IS_PRIVATE(tp))) {
             return TRUE;
         }
@@ -5534,8 +5635,10 @@ static void outx_enumDecl(int l, ID id)
     if (id == NULL)
         return;
 
-    outx_tagOfDeclNoChild(l, "%s type=\"%s\"", ID_LINE(id), "FenumDecl",
-                          getTypeID(ID_TYPE(id)));
+    sds_string tid = sdsempty();
+    getTypeID(ID_TYPE(id), &tid);
+    outx_tagOfDeclNoChild(l, "%s type=\"%s\"", ID_LINE(id), "FenumDecl", tid);
+    sdsfree(tid);
 }
 
 static int qsort_compare_id(const void *v1, const void *v2)
@@ -5647,8 +5750,8 @@ static int is_id_used_in_struct_member(ID id, TYPE_DESC sTp)
 {
     /*
      * FIXME:
-     *	Actually, it is not checked if id is used in sTp's member.
-     *	Instead, just checking line number.
+     *    Actually, it is not checked if id is used in sTp's member.
+     *    Instead, just checking line number.
      */
     ID mId;
 
@@ -5683,7 +5786,7 @@ static void emit_decl(int l, ID id)
         return;
     }
 
-    if (!is_inside_interface && GET_CRT_FUNCEP() != NULL &&
+    if (!outx_ctx->is_inside_interface && GET_CRT_FUNCEP() != NULL &&
         EXT_PROC_IS_PROCEDUREDECL(GET_CRT_FUNCEP())) {
 
         /*
@@ -6009,7 +6112,7 @@ static void outx_moduleProcedureDecl(int l, EXT_ID ep, SYMBOL parentName)
 {
     const int l1 = l + 1;
 
-    if (is_emitting_xmod() == FALSE) {
+    if (!is_emitting_xmod()) {
         if (EXT_TAG(ep) == STG_EXT && !EXT_IS_OFMODULE(ep)) {
             if (EXT_PROC_IS_MODULE_SPECIFIED(ep)) {
                 outx_tagOfDecl1(
@@ -6148,7 +6251,7 @@ static void outx_function_as_interfaceDecl(int l, EXT_ID ep)
 
     CRT_FUNCEP_PUSH(NULL);
     outx_printi(l, "<FinterfaceDecl");
-    is_inside_interface = TRUE;
+    outx_ctx->is_inside_interface = true;
 
     if (TYPE_IS_ABSTRACT(EXT_PROC_TYPE(ep)))
         outx_true(TRUE, "is_abstract");
@@ -6157,7 +6260,7 @@ static void outx_function_as_interfaceDecl(int l, EXT_ID ep)
     outx_printi(0, ">\n");
     outx_functionDecl(l + 1, ep);
     outx_close(l, "FinterfaceDecl");
-    is_inside_interface = FALSE;
+    outx_ctx->is_inside_interface = false;
     CRT_FUNCEP_POP();
 }
 
@@ -6192,7 +6295,7 @@ static void outx_interfaceDecl(int l, EXT_ID ep)
 
     CRT_FUNCEP_PUSH(NULL);
     outx_printi(l, "<FinterfaceDecl");
-    is_inside_interface = TRUE;
+    outx_ctx->is_inside_interface = true;
 
     switch (EXT_PROC_INTERFACE_CLASS(ep)) {
         case INTF_DECL:
@@ -6204,8 +6307,12 @@ static void outx_interfaceDecl(int l, EXT_ID ep)
             break;
         case INTF_OPERATOR:
         case INTF_USEROP:
-            outx_printi(0, " name=\"%s\"",
-                        getXmlEscapedStr(SYM_NAME(EXT_SYM(ep))));
+            {
+                sds_string s = sdsempty();
+                getXmlEscapedStr(SYM_NAME(EXT_SYM(ep)), &s);
+                outx_printi(0, " name=\"%s\"", s);
+                sdsfree(s);
+            }
             outx_true(TRUE, "is_operator");
             break;
         case INTF_GENERIC_WRITE_FORMATTED:
@@ -6232,7 +6339,7 @@ static void outx_interfaceDecl(int l, EXT_ID ep)
     outx_printi(0, ">\n");
     outx_moduleProcedureDecls(l + 1, extids, EXT_SYM(ep));
     outx_close(l, "FinterfaceDecl");
-    is_inside_interface = FALSE;
+    outx_ctx->is_inside_interface = false;
     CRT_FUNCEP_POP();
 }
 
@@ -6273,7 +6380,7 @@ static void outx_moduleDefinition(int l, EXT_ID ep)
 {
     const int l1 = l + 1;
 
-    is_outputed_module = TRUE;
+    outx_ctx->is_outputed_module = true;
 
     SET_CRT_FUNCEP(NULL);
 
@@ -6297,7 +6404,7 @@ static void outx_moduleDefinition(int l, EXT_ID ep)
     outx_contains(l1, ep);
     outx_close(l, "FmoduleDefinition");
 
-    is_outputed_module = FALSE;
+    outx_ctx->is_outputed_module = false;
 }
 
 /**
@@ -6323,8 +6430,8 @@ static const char *getTimestamp()
 {
     const time_t t = time(NULL);
     struct tm *ltm = localtime(&t);
-    strftime(s_timestamp, CEXPR_OPTVAL_CHARLEN, "%F %T", ltm);
-    return s_timestamp;
+    strftime(outx_ctx->s_timestamp, CEXPR_OPTVAL_CHARLEN, "%F %T", ltm);
+    return outx_ctx->s_timestamp;
 }
 
 /**
@@ -6423,7 +6530,7 @@ static void collect_types(EXT_ID extid)
     TYPE_DESC sTp;
 
     collect_types1(extid);
-    FOREACH_TYPE_EXT_ID (te, type_ext_id_list) {
+    FOREACH_TYPE_EXT_ID (te, outx_ctx->type_ext_id_list) {
         TYPE_DESC tp = EXT_PROC_TYPE(te->ep);
         if (tp && EXT_TAG(te->ep) == STG_EXT) {
             sTp = reduce_type(EXT_PROC_TYPE(te->ep));
@@ -6435,7 +6542,7 @@ static void collect_types(EXT_ID extid)
     /*
      * now mark type-bound procedures
      */
-    for (tp = tbp_list; tp != NULL; tp = tq) {
+    for (tp = outx_ctx->tbp_list; tp != NULL; tp = tq) {
         tq = TYPE_LINK(tp);
         TYPE_LINK(tp) = NULL;
         TYPE_IS_REFERENCED(tp) = FALSE;
@@ -6452,7 +6559,7 @@ static void collect_types_inner(EXT_ID extid)
     TYPE_DESC sTp;
 
     collect_types1(extid);
-    FOREACH_TYPE_EXT_ID (te, type_ext_id_list) {
+    FOREACH_TYPE_EXT_ID (te, outx_ctx->type_ext_id_list) {
         TYPE_DESC tp = EXT_PROC_TYPE(te->ep);
         if (tp && EXT_TAG(te->ep) == STG_EXT) {
             sTp = reduce_type(EXT_PROC_TYPE(te->ep));
@@ -6472,7 +6579,7 @@ static void outx_typeTable(int l)
 
     outx_tag(l, "typeTable");
 
-    for (tp = type_list; tp != NULL; tp = TYPE_LINK(tp)) {
+    for (tp = outx_ctx->type_list; tp != NULL; tp = TYPE_LINK(tp)) {
         outx_type(l1, tp);
     }
 
@@ -6545,32 +6652,35 @@ void output_XcodeML_file()
     if (module_compile_enabled())
         return; // DO NOTHING
 
-    type_list = NULL;
+    outx_ctx->type_list = NULL;
 
     init_sets();
 
-    type_module_proc_list = NULL;
-    type_module_proc_last = NULL;
-    type_ext_id_list = NULL;
-    type_ext_id_last = NULL;
-    tbp_list = NULL;
-    tbp_list_tail = NULL;
+    outx_ctx->type_ext_id_list = NULL;
+    outx_ctx->type_ext_id_last = NULL;
+    outx_ctx->tbp_list = NULL;
+    outx_ctx->tbp_list_tail = NULL;
 
     collect_types(EXTERNAL_SYMBOLS);
     SET_CRT_FUNCEP(NULL);
 
-    print_fp = src_output();
+    outx_ctx->print_fp = src_output();
     const int l = 0, l1 = l + 1;
 
-    outx_printi(
-        l,
-        "<XcodeProgram source=\"%s\"\n"
-        "              language=\"%s\"\n"
-        "              time=\"%s\"\n"
-        "              compiler-info=\"%s\"\n"
-        "              version=\"%s\">\n",
-        getXmlEscapedStr(sdslen(ctx->src_file_path) != 0  ? ctx->src_file_path : "<stdin>"),
-        F_TARGET_LANG, getTimestamp(), F_FRONTEND_NAME, F_FRONTEND_VER);
+    {
+        sds_string s = sdsempty();
+        getXmlEscapedStr(sdslen(ctx->src_file_path) != 0  ? ctx->src_file_path : "<stdin>", &s);
+        outx_printi(
+            l,
+            "<XcodeProgram source=\"%s\"\n"
+            "              language=\"%s\"\n"
+            "              time=\"%s\"\n"
+            "              compiler-info=\"%s\"\n"
+            "              version=\"%s\">\n",
+            s,
+            F_TARGET_LANG, getTimestamp(), F_FRONTEND_NAME, F_FRONTEND_VER);
+        sdsfree(s);
+    }
 
     outx_typeTable(l1);
     outx_globalSymbols(l1);
@@ -6607,8 +6717,12 @@ static void outx_id_mod(int l, ID id)
     const char *sclass = get_sclass(id);
 
     outx_print(" sclass=\"%s\"", sclass);
-    outx_print(" original_name=\"%s\"",
-               getXmlEscapedStr(SYM_NAME(id->use_assoc->original_name)));
+    {
+        sds_string s = sdsempty();
+        getXmlEscapedStr(SYM_NAME(id->use_assoc->original_name), &s);
+        outx_print(" original_name=\"%s\"", s);
+        sdsfree(s);
+    }
     outx_print(" declared_in=\"%s\"", SYM_NAME(id->use_assoc->module_name));
     if (ID_IS_AMBIGUOUS(id))
         outx_print(" is_ambiguous=\"true\"");
@@ -6784,35 +6898,33 @@ int output_module_file(struct module *mod, const char *filename)
     TYPE_DESC sTp;
     TYPE_DESC tp;
     TYPE_DESC tq;
-    int oEmitMode;
+    bool oEmitMode;
     expr modTypeList;
     list lp;
     expv v;
 
     if (module_compile_enabled()) {
-        print_fp = src_output();
+        outx_ctx->print_fp = src_output();
     } else {
-        if ((print_fp = fopen(filename, "w")) == NULL) {
+        if ((outx_ctx->print_fp = fopen(filename, "w")) == NULL) {
             fatal("couldn't open module file to write: %s", filename);
             return FALSE;
         }
     }
 
-    is_emitting_for_submodule = MODULE_IS_FOR_SUBMODULE(mod);
+    outx_ctx->is_emitting_for_submodule = MODULE_IS_FOR_SUBMODULE(mod);
 
     init_sets();
 
     oEmitMode = is_emitting_xmod();
-    set_module_emission_mode(TRUE);
+    set_module_emission_mode(true);
 
-    type_list = NULL;
+    outx_ctx->type_list = NULL;
 
-    type_module_proc_list = NULL;
-    type_module_proc_last = NULL;
-    type_ext_id_list = NULL;
-    type_ext_id_last = NULL;
-    tbp_list = NULL;
-    tbp_list_tail = NULL;
+    outx_ctx->type_ext_id_list = NULL;
+    outx_ctx->type_ext_id_last = NULL;
+    outx_ctx->tbp_list = NULL;
+    outx_ctx->tbp_list_tail = NULL;
 
     /*
      * collect types used in this module
@@ -6824,7 +6936,7 @@ int output_module_file(struct module *mod, const char *filename)
         // if id is external,  ...
         if (ep != NULL) {
             collect_types1(ep);
-            FOREACH_TYPE_EXT_ID (te, type_ext_id_list) {
+            FOREACH_TYPE_EXT_ID (te, outx_ctx->type_ext_id_list) {
                 TYPE_DESC tp = EXT_PROC_TYPE(te->ep);
                 if (tp && EXT_TAG(te->ep) == STG_EXT) {
                     sTp = reduce_type(EXT_PROC_TYPE(te->ep));
@@ -6849,7 +6961,7 @@ int output_module_file(struct module *mod, const char *filename)
     /*
      * now mark type-bound procedures
      */
-    for (tp = tbp_list; tp != NULL; tp = tq) {
+    for (tp = outx_ctx->tbp_list; tp != NULL; tp = tq) {
         tq = TYPE_LINK(tp);
         TYPE_LINK(tp) = NULL;
         TYPE_IS_REFERENCED(tp) = FALSE;
@@ -6864,10 +6976,10 @@ int output_module_file(struct module *mod, const char *filename)
     set_module_emission_mode(oEmitMode);
 
     if (!module_compile_enabled()) {
-        fclose(print_fp);
+        fclose(outx_ctx->print_fp);
     }
 
-    is_emitting_for_submodule = FALSE;
+    outx_ctx->is_emitting_for_submodule = false;
 
     return TRUE;
 }
@@ -6932,4 +7044,24 @@ void final_fixup()
             fixup_function_call(v);
         }
     }
+}
+
+void init_out_xcodeml_context(out_xcodeml_context* ctx)
+{
+    ctx->is_inside_interface = false;
+    ctx->current_function_top = 0;
+    ctx->is_outputed_module = false;
+    ctx->is_emitting_module = false;
+    memset(ctx->s_timestamp, 0, CEXPR_OPTVAL_CHARLEN);
+}
+
+void free_out_xcodeml_context(out_xcodeml_context* ctx)
+{
+}
+
+THREAD_LOCAL out_xcodeml_context* outx_ctx;
+
+void set_out_xcodeml_context(out_xcodeml_context* in_ctx)
+{
+    outx_ctx = in_ctx;
 }

--- a/F-FrontEnd/src/F-output-xcodeml.h
+++ b/F-FrontEnd/src/F-output-xcodeml.h
@@ -31,7 +31,4 @@ extern int output_module_file(struct module *, const char *);
 #define F_FRONTEND_VER "1.0"
 #define F_MODULE_VER "1.0"
 
-extern char s_timestamp[];
-extern char s_xmlIndent[];
-
 #endif /* _F_XCODEML_H_ */

--- a/F-FrontEnd/src/F95-main.c
+++ b/F-FrontEnd/src/F95-main.c
@@ -113,7 +113,7 @@ static void usage(const cli_options* opts)
 
 void parse_cli_args(cli_options* opts, int argc, char *argv[])
 {
-        set_bin_name(opts, argv[0]);
+    set_bin_name(opts, argv[0]);
     --argc;
     ++argv;
 
@@ -278,19 +278,19 @@ void parse_cli_args(cli_options* opts, int argc, char *argv[])
 }
 
 static inline int to_lang_spec_set(int spec) {
-	switch (spec) {
-	case F77_SPEC:
-		return LANGSPEC_F77_SET;
-	case F90_SPEC:
-		return LANGSPEC_F90_SET;
-	case F95_SPEC:
-		return LANGSPEC_F95_SET;
-	case FDEFAULT_SPEC:
-		return LANGSPEC_DEFAULT_SET;
-	default:
+    switch (spec) {
+    case F77_SPEC:
+        return LANGSPEC_F77_SET;
+    case F90_SPEC:
+        return LANGSPEC_F90_SET;
+    case F95_SPEC:
+        return LANGSPEC_F95_SET;
+    case FDEFAULT_SPEC:
+        return LANGSPEC_DEFAULT_SET;
+    default:
         cmd_error_exit("unknown Fortran lang spec : %d", spec);
         return 0; //Unreachable code
-	}
+    }
 }
 
 void init_context_from_cli_opts(ffront_context* local_ctx, const cli_options* opts)
@@ -324,31 +324,31 @@ void init_context_from_cli_opts(ffront_context* local_ctx, const cli_options* op
     params->max_cont_line = get_max_cont_line(opts);
     params->do_implicit_undef_enabled= get_do_implicit_undef(opts);
     int sz = get_default_single_real_type_size(opts);
-	switch (sz) {
-		case SIZEOF_FLOAT:
-			params->default_single_real_type = TYPE_REAL;
-			break;
-		case SIZEOF_DOUBLE:
-			params->default_single_real_type = TYPE_DREAL;
-			break;
-		default: {
-			cmd_error_exit("invalid single-real size %d, must be %d or %d.", sz,
-			SIZEOF_FLOAT, SIZEOF_DOUBLE);
-		}
-	}
+    switch (sz) {
+        case SIZEOF_FLOAT:
+            params->default_single_real_type = TYPE_REAL;
+            break;
+        case SIZEOF_DOUBLE:
+            params->default_single_real_type = TYPE_DREAL;
+            break;
+        default: {
+            cmd_error_exit("invalid single-real size %d, must be %d or %d.", sz,
+            SIZEOF_FLOAT, SIZEOF_DOUBLE);
+        }
+    }
     sz = get_default_double_real_type_size(opts);
-	switch (sz) {
-		case SIZEOF_FLOAT:
-			params->default_double_real_type = TYPE_REAL;
-			break;
-		case SIZEOF_DOUBLE:
-			params->default_double_real_type = TYPE_DREAL;
-			break;
-		default: {
-			cmd_error_exit("invalid double-real size %d, must be %d or %d.", sz,
-			SIZEOF_FLOAT, SIZEOF_DOUBLE);
-		}
-	}
+    switch (sz) {
+        case SIZEOF_FLOAT:
+            params->default_double_real_type = TYPE_REAL;
+            break;
+        case SIZEOF_DOUBLE:
+            params->default_double_real_type = TYPE_DREAL;
+            break;
+        default: {
+            cmd_error_exit("invalid double-real size %d, must be %d or %d.", sz,
+            SIZEOF_FLOAT, SIZEOF_DOUBLE);
+        }
+    }
     params->module_compile_enabled = get_module_compile_enabled(opts);
     copy_sds_string_vector(&params->inc_dir_paths, get_inc_dir_paths(opts));
     copy_sds_string_vector(&params->xmod_inc_dir_paths, get_xmod_inc_dir_paths(opts));
@@ -471,6 +471,29 @@ Done:
     return num_errors() != 0 ? EXITCODE_ERR : EXITCODE_OK;
 }
 
+int execute_cli_opts(const cli_options* opts)
+{
+    if(get_print_help(opts))
+    {
+        usage(opts);
+        return EXITCODE_OK;
+    }
+    else if(get_print_opts(opts))
+    {
+        print_cli_options(opts, stdout);
+        return EXITCODE_OK;
+    }
+#ifdef HAVE_SETLOCALE
+    (void)setlocale(LC_ALL, "C");
+#endif /* HAVE_SETLOCALE */
+    ffront_params params;
+    ffront_context local_ctx = {&params};
+    init_context_from_cli_opts(&local_ctx, opts);
+    set_ffront_context(&local_ctx);
+    const int ret_code = execute();
+    return ret_code;
+}
+
 int main(int argc, char *argv[])
 {
 #ifdef HAVE_SETLOCALE
@@ -479,21 +502,7 @@ int main(int argc, char *argv[])
     cli_options opts;
     init_cli_options(&opts);
     parse_cli_args(&opts, argc, argv);
-    if(get_print_help(&opts))
-    {
-        usage(&opts);
-        return EXITCODE_OK;
-    }
-    else if(get_print_opts(&opts))
-    {
-    	print_cli_options(&opts, stdout);
-        return EXITCODE_OK;
-    }
-    ffront_params params;
-    ffront_context local_ctx = {&params};
-    init_context_from_cli_opts(&local_ctx, &opts);
-    set_ffront_context(&local_ctx);
-    const int ret_code = execute();
+    const int ret_code = execute_cli_opts(&opts);
     free_cli_options(&opts);
     return ret_code;
 }

--- a/F-FrontEnd/src/F95-main.c
+++ b/F-FrontEnd/src/F95-main.c
@@ -494,7 +494,11 @@ int execute_cli_opts(const cli_options* opts)
     return ret_code;
 }
 
-int main(int argc, char *argv[])
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+int execute_args(int argc, char *argv[])
 {
 #ifdef HAVE_SETLOCALE
     (void)setlocale(LC_ALL, "C");
@@ -506,6 +510,9 @@ int main(int argc, char *argv[])
     free_cli_options(&opts);
     return ret_code;
 }
+#if defined(__cplusplus)
+}
+#endif
 
 bool search_include_path(const char *filename, sds_string* path)
 {

--- a/F-FrontEnd/src/F95-main.c
+++ b/F-FrontEnd/src/F95-main.c
@@ -99,6 +99,7 @@ static void usage(const cli_options* opts)
         "-endlineno                output the endlineno attribute.", "",
         "internal options:", "-d                        enable debug mode.",
         "-no-module-cache          always load module from file.",
+        "-no-time                  do not add timestamp to xcodeml.",
 
         NULL};
     const char *const *p = usages;
@@ -290,7 +291,9 @@ void parse_cli_args(cli_options* opts, int argc, char *argv[])
             break;
         } else if (strcmp(argv[0], "-no-module-cache") == 0) {
             set_module_cache_enabled(opts, false);
-        } else {
+        } else if (strcmp(argv[0], "-no-time") == 0) {
+            set_add_timestamp_enabled(opts, false);
+        }  else {
             cmd_error_exit("unknown option : %s", argv[0]);
         }
         --argc;
@@ -343,6 +346,7 @@ void init_context_from_cli_opts(ffront_context* local_ctx, const cli_options* op
     params->cdir_enabled = get_cdir_enabled(opts);
     params->pgi_enabled = get_pgi_enabled(opts);
     params->module_cache_enabled = get_module_cache_enabled(opts);
+    params->add_timestamp_enabled = get_add_timestamp_enabled(opts);
     const bool force_fixed_format = get_force_fixed_format_enabled(opts);
 
     local_ctx->fixed_format_enabled = force_fixed_format;

--- a/F-FrontEnd/src/Makefile.in
+++ b/F-FrontEnd/src/Makefile.in
@@ -21,7 +21,7 @@ OBJECTS = F95-main.o C-expr-mem.o C-exprcode.o F-datatype.o F-ident.o \
 	  xcodeml-node.o xcodeml-parse.o xcodeml-util.o xcodeml-type.o \
 	  xcodeml-traverse.o xcodeml-output-F.o F-dump.o F-type-attr-tbl.o \
 	  module-manager.o hash.o F-input-xmod.o F-module-procedure.o F-second-pass.o \
-	  sds.o cli_options.o utils.o F-front-context.o F-driver.o
+	  sds.o cli_options.o utils.o F-front-context.o F-driver.o io_cache.o
 HEADERS = C-OMP.h C-ACC.h C-XMP.h C-expr.h C-exprcode.h F-datatype.h F-front.h F-ident.h \
 	  F-input-xmod.h F-intrinsics-types.h F-module-procedure.h F-output-xcodeml.h \
 	  F-second-pass.h hash.h module-manager.h xcodeml-module.h xcodeml-node.h xcodeml.h 3rdparty/sds/sds.h cli_options.h

--- a/F-FrontEnd/src/Makefile.in
+++ b/F-FrontEnd/src/Makefile.in
@@ -21,7 +21,7 @@ OBJECTS = F95-main.o C-expr-mem.o C-exprcode.o F-datatype.o F-ident.o \
 	  xcodeml-node.o xcodeml-parse.o xcodeml-util.o xcodeml-type.o \
 	  xcodeml-traverse.o xcodeml-output-F.o F-dump.o F-type-attr-tbl.o \
 	  module-manager.o hash.o F-input-xmod.o F-module-procedure.o F-second-pass.o \
-	  sds.o cli_options.o utils.o F-front-context.o
+	  sds.o cli_options.o utils.o F-front-context.o F-driver.o
 HEADERS = C-OMP.h C-ACC.h C-XMP.h C-expr.h C-exprcode.h F-datatype.h F-front.h F-ident.h \
 	  F-input-xmod.h F-intrinsics-types.h F-module-procedure.h F-output-xcodeml.h \
 	  F-second-pass.h hash.h module-manager.h xcodeml-module.h xcodeml-node.h xcodeml.h 3rdparty/sds/sds.h cli_options.h

--- a/F-FrontEnd/src/cli_options.c
+++ b/F-FrontEnd/src/cli_options.c
@@ -24,6 +24,7 @@ static const bool DEFAULT_OCL_ENABLED = false;
 static const bool DEFAULT_PGI_ENABLED = false;
 static const bool DEFAULT_CDIR_ENABLED = false;
 static const bool DEFAULT_MODULE_CACHE_ENABLED = true;
+static const bool DEFAULT_ADD_TIMESTAMP_ENABLED = true;
 static const bool DEFAULT_PRINT_HELP = false;
 static const bool DEFAULT_PRINT_OPTS = false;
 
@@ -60,6 +61,7 @@ void init_cli_options(cli_options* opts)
     opts->cdir_enabled = DEFAULT_CDIR_ENABLED;
     opts->pgi_enabled = DEFAULT_PGI_ENABLED;
     opts->module_cache_enabled = DEFAULT_MODULE_CACHE_ENABLED;
+    opts->add_timestamp_enabled = DEFAULT_ADD_TIMESTAMP_ENABLED;
     opts->print_help = DEFAULT_PRINT_HELP;
     opts->print_opts = DEFAULT_PRINT_OPTS;
 }

--- a/F-FrontEnd/src/cli_options.c
+++ b/F-FrontEnd/src/cli_options.c
@@ -1,5 +1,4 @@
 #include "cli_options.h"
-#include "F-front.h"
 
 static const int DEFAULT_MAX_PATHS = 256;
 static const int DEFAULT_MAX_CONT_LINE = 255;
@@ -38,11 +37,11 @@ void init_cli_options(cli_options* opts)
     opts->xmod_inc_dir_paths = vector_init(sds_string, DEFAULT_MAX_PATHS);
     opts->max_line_len = DEFAULT_MAX_LINE_LEN;
     opts->max_cont_line = DEFAULT_MAX_CONT_LINE;
-    opts->lang_spec_set = LANGSPEC_DEFAULT_SET;
+    opts->lang_spec_set = FDEFAULT_SPEC;
     opts->auto_save_attr_kb = DEFAULT_AUTO_SAVE_ATTR_KB;
     opts->max_name_len = DEFAULT_MAX_NAME_LEN;
-    opts->default_single_real_type = TYPE_REAL;
-    opts->default_double_real_type = TYPE_DREAL;
+    opts->default_single_real_type_size = SIZEOF_FLOAT;
+    opts->default_double_real_type_size = SIZEOF_DOUBLE;
     opts->debug_enabled = DEFAULT_DEBUG_ENABLED;
     opts->yacc_debug_enabled = DEFAULT_YACC_DEBUG_ENABLED;
     opts->module_compile_enabled = DEFAULT_MODULE_COMPILE_ENABLED;
@@ -87,10 +86,9 @@ void free_cli_options(cli_options* opts)
     } \
 }
 #define PRINT_INT(name) fprintf(out, "%s: %i\n", #name, get_ ## name(opts))
-#define PRINT_ENUM(name) fprintf(out, "%s: %i\n", #name, (int)get_ ## name(opts))
 #define PRINT_BOOL(name) fprintf(out, "%s: %s\n", #name, get_ ## name(opts) ? "true" : "false")
 
-void print_options(const cli_options* opts, FILE* out)
+void print_cli_options(const cli_options* opts, FILE* out)
 {
     PRINT_STRING(bin_name);
     PRINT_STRING(src_file_path);
@@ -103,8 +101,8 @@ void print_options(const cli_options* opts, FILE* out)
     PRINT_INT(lang_spec_set);
     PRINT_INT(auto_save_attr_kb);
     PRINT_INT(max_name_len);
-    PRINT_ENUM(default_single_real_type);
-    PRINT_ENUM(default_double_real_type);
+    PRINT_INT(default_single_real_type_size);
+    PRINT_INT(default_double_real_type_size);
     PRINT_BOOL(debug_enabled);
     PRINT_BOOL(yacc_debug_enabled);
     PRINT_BOOL(module_compile_enabled);

--- a/F-FrontEnd/src/cli_options.h
+++ b/F-FrontEnd/src/cli_options.h
@@ -7,6 +7,14 @@
 #include "c_vector/vector.h"
 #include <stdio.h>
 
+enum FORTRAN_SPEC
+{
+	F77_SPEC = 77,
+	F90_SPEC = 90,
+	F95_SPEC = 95,
+	FDEFAULT_SPEC = 2008
+};
+
 typedef struct {
     sds_string bin_name;
     sds_string src_file_path;
@@ -16,11 +24,11 @@ typedef struct {
     sds_string_vector xmod_inc_dir_paths;
     int max_line_len;
     int max_cont_line;
-    int lang_spec_set;
+    enum FORTRAN_SPEC lang_spec_set;
     int auto_save_attr_kb;
     int max_name_len;
-    BASIC_DATA_TYPE default_single_real_type;
-    BASIC_DATA_TYPE default_double_real_type;
+    int default_single_real_type_size;
+    int default_double_real_type_size;
     bool debug_enabled;
     bool yacc_debug_enabled;
     bool module_compile_enabled;
@@ -46,7 +54,7 @@ typedef struct {
 
 void init_cli_options(cli_options *opts);
 void free_cli_options(cli_options *opts);
-void print_options(const cli_options* opts, FILE* out);
+void print_cli_options(const cli_options* opts, FILE* out);
 
 static inline void set_bin_name(cli_options *opts, const char *name) {
     set_sds_string(&opts->bin_name, name);
@@ -114,10 +122,10 @@ static inline void set_max_cont_line(cli_options *opts, int val) {
 static inline int get_max_cont_line(const cli_options *opts) {
     return opts->max_cont_line;
 }
-static inline void set_lang_spec_set(cli_options *opts, int val) {
+static inline void set_lang_spec_set(cli_options *opts, enum FORTRAN_SPEC val) {
     opts->lang_spec_set = val;
 }
-static inline int get_lang_spec_set(const cli_options *opts) {
+static inline enum FORTRAN_SPEC get_lang_spec_set(const cli_options *opts) {
     return opts->lang_spec_set;
 }
 static inline void set_auto_save_attr_kb(cli_options *opts, int val) {
@@ -132,21 +140,21 @@ static inline void set_max_name_len(cli_options *opts, int val) {
 static inline int get_max_name_len(const cli_options *opts) {
     return opts->max_name_len;
 }
-static inline void set_default_single_real_type(cli_options *opts,
-        BASIC_DATA_TYPE val) {
-    opts->default_single_real_type = val;
+static inline void set_default_single_real_type_size(cli_options *opts,
+        int val) {
+    opts->default_single_real_type_size = val;
 }
-static inline BASIC_DATA_TYPE get_default_single_real_type(
+static inline int get_default_single_real_type_size(
         const cli_options *opts) {
-    return opts->default_single_real_type;
+    return opts->default_single_real_type_size;
 }
-static inline void set_default_double_real_type(cli_options *opts,
-        BASIC_DATA_TYPE val) {
-    opts->default_double_real_type = val;
+static inline void set_default_double_real_type_size(cli_options *opts,
+        int val) {
+    opts->default_double_real_type_size = val;
 }
-static inline BASIC_DATA_TYPE get_default_double_real_type(
+static inline int get_default_double_real_type_size(
         const cli_options *opts) {
-    return opts->default_double_real_type;
+    return opts->default_double_real_type_size;
 }
 static inline void set_debug_enabled(cli_options *opts, bool val) {
     opts->debug_enabled = val;

--- a/F-FrontEnd/src/cli_options.h
+++ b/F-FrontEnd/src/cli_options.h
@@ -39,6 +39,7 @@ typedef struct {
     bool cdir_enabled;
     bool pgi_enabled;
     bool module_cache_enabled;
+    bool add_timestamp_enabled;
     bool print_help;
     bool print_opts;
 } cli_options;
@@ -255,6 +256,12 @@ static inline void set_module_cache_enabled(cli_options *opts, bool val) {
 }
 static inline bool get_module_cache_enabled(const cli_options *opts) {
     return opts->module_cache_enabled;
+}
+static inline void set_add_timestamp_enabled(cli_options *opts, bool val) {
+    opts->add_timestamp_enabled = val;
+}
+static inline bool get_add_timestamp_enabled(const cli_options *opts) {
+    return opts->add_timestamp_enabled;
 }
 static inline void set_print_help(cli_options *opts, bool val) {
     opts->print_help = val;

--- a/F-FrontEnd/src/cpp/io_cache.cpp
+++ b/F-FrontEnd/src/cpp/io_cache.cpp
@@ -1,0 +1,150 @@
+/* Author: Mikhail Zhigun */
+#include "io_cache.h"
+#include "omni_errors.h"
+#include <unordered_map>
+#include <string>
+#include <iostream>
+
+namespace
+{
+    struct InputEntry
+    {
+        void* start;
+        size_t size;
+    };
+    struct OutputEntry
+    {
+        OutputEntry(char* start, size_t size, FILE* handle):
+            start{start},
+            size{size},
+            handle{handle}
+        {}
+        OutputEntry(const OutputEntry&) = delete;
+        OutputEntry(OutputEntry&& e):
+            start{e.start},
+            size{e.size},
+            handle{e.handle}
+        {
+            e.start = nullptr;
+            e.size = 0;
+            e.handle = nullptr;
+        }
+        char* start;
+        size_t size;
+        FILE* handle;
+        ~OutputEntry()
+        {
+            if(start)
+            {
+                free(start);
+            }
+        }
+    };
+}
+
+struct s_io_cache
+{
+    std::unordered_map<std::string, InputEntry> in_entries;
+    std::unordered_map<std::string, OutputEntry> out_entries;
+};
+
+io_cache create_io_cache()
+{
+    return new s_io_cache;
+}
+
+void free_io_cache(io_cache cache)
+{
+    delete cache;
+}
+
+void io_cache_add_input_file(io_cache cache, const char* name, void* start, size_t size)
+{
+    cache->in_entries[std::string{name}] = InputEntry{start, size};
+}
+
+FILE* io_cache_get_input_file(io_cache cache, const char* name)
+{
+    auto entryIt = cache->in_entries.find(std::string{name});
+    if(entryIt != cache->in_entries.end())
+    {
+        const auto& entry = (*entryIt).second;
+        return fmemopen(entry.start, entry.size, "r");
+    }
+    else
+    {
+        return nullptr;
+    }
+}
+
+bool io_cache_get_input_file_as_mem(io_cache cache, const char* name, void** startAddress, size_t* size)
+{
+    auto entryIt = cache->in_entries.find(std::string{name});
+    if(entryIt != cache->in_entries.end())
+    {
+        const auto& entry = (*entryIt).second;
+        *startAddress = entry.start;
+        *size = entry.size;
+        return true;
+    }
+    else
+    {
+        *startAddress = nullptr;
+        *size = 0;
+        return false;
+    }
+}
+
+void io_cache_add_output_file(io_cache cache, const char* name)
+{
+    auto& entry = (*cache->out_entries.emplace(std::string{name}, OutputEntry{nullptr, 0, nullptr}).first).second;
+    entry.handle = open_memstream(&entry.start, &entry.size);
+}
+
+FILE* io_cache_get_output_file(io_cache cache, const char* name)
+{
+    auto entryIt = cache->out_entries.find(std::string{name});
+    if(entryIt != cache->out_entries.end())
+    {
+        const auto& entry = (*entryIt).second;
+        return entry.handle;
+    }
+    else
+    {
+        return nullptr;
+    }
+}
+
+void io_cache_get_output_file_as_mem(io_cache cache, const char* name, void** startAddress, size_t* size)
+{
+    auto entryIt = cache->out_entries.find(std::string{name});
+    if(entryIt != cache->out_entries.end())
+    {
+        const auto& entry = (*entryIt).second;
+        *startAddress = reinterpret_cast<void*>(entry.start);
+        *size = entry.size;
+    }
+    else
+    {
+        *startAddress = nullptr;
+        *size = 0;
+    }
+}
+
+
+void debug_print_io_cache(io_cache cache)
+{
+    std::cerr << "Input entries:" << std::endl;
+    for (auto const& it : cache->in_entries)
+    {
+        std::cerr << it.first  << " : " << it.second.start << " " << it.second.size << std::endl;
+    }
+    std::cerr << "Output entries:" << std::endl;
+    for (auto const& it : cache->out_entries)
+    {
+        std::cerr << it.first  << " : " << it.second.start << " " << it.second.size << std::endl;
+    }
+    std::cerr << std::endl;
+}
+
+

--- a/F-FrontEnd/src/cpp/omni-errors.cpp
+++ b/F-FrontEnd/src/cpp/omni-errors.cpp
@@ -1,3 +1,4 @@
+/* Author: Mikhail Zhigun */
 #include "omni_errors.h"
 #include <sstream>
 #include <exception>

--- a/F-FrontEnd/src/io_cache.c
+++ b/F-FrontEnd/src/io_cache.c
@@ -1,0 +1,48 @@
+/* Author: Mikhail Zhigun */
+#include "io_cache.h"
+#include "omni_errors.h"
+
+#if !defined(__cplusplus)
+
+io_cache create_io_cache()
+{
+    return NULL;
+}
+
+void free_io_cache(io_cache cache)
+{}
+
+void io_cache_add_input_file(io_cache cache, const char* filename, void* startAddress, size_t size)
+{
+    FATAL_ERROR_WITH_MSG("io_cache_add_input_file() not implemented in C build");
+}
+
+FILE* io_cache_get_input_file(io_cache cache, const char* filename)
+{
+    return NULL;
+}
+
+bool io_cache_get_input_file_as_mem(io_cache cache, const char* name, void** startAddress, size_t* size)
+{
+    *startAddress = NULL;
+    *size = 0;
+    return false;
+}
+
+void io_cache_add_output_file(io_cache cache, const char* filename)
+{
+    FATAL_ERROR_WITH_MSG("io_cache_add_output_file() not implemented in C build");
+}
+
+FILE* io_cache_get_output_file(io_cache cache, const char* filename)
+{
+    return NULL;
+}
+
+void io_cache_get_output_file_as_mem(io_cache cache, const char* filename, void** startAddress, size_t* size)
+{
+    FATAL_ERROR_WITH_MSG("io_cache_add_entry() not implemented in C build");
+}
+
+#endif
+

--- a/F-FrontEnd/src/io_cache.h
+++ b/F-FrontEnd/src/io_cache.h
@@ -1,0 +1,26 @@
+/* Author: Mikhail Zhigun */
+#ifndef IO_CACHE_H
+#define IO_CACHE_H
+
+/* IO cache provides storage and lookup for input files (src, xmods etc.) mapped and stored in memory,
+ * as well as output files wrapped in C streams.
+   It is only implemented in c++ build because functionality is only relevant for JNI interface.
+*/
+
+#include "bool.h"
+#include <stdio.h>
+
+struct s_io_cache;
+typedef struct s_io_cache* io_cache;
+
+io_cache create_io_cache();
+void free_io_cache(io_cache cache);
+void io_cache_add_input_file(io_cache cache, const char* filename, void* startAddress, size_t size);
+FILE* io_cache_get_input_file(io_cache cache, const char* filename);
+bool io_cache_get_input_file_as_mem(io_cache cache, const char* filename, void** startAddress, size_t* size);
+void io_cache_add_output_file(io_cache cache, const char* filename);
+FILE* io_cache_get_output_file(io_cache cache, const char* filename);
+void io_cache_get_output_file_as_mem(io_cache cache, const char* filename, void** startAddress, size_t* size);
+void debug_print_io_cache(io_cache cache);
+
+#endif //IO_CACHE_H

--- a/F-FrontEnd/src/module-manager.c
+++ b/F-FrontEnd/src/module-manager.c
@@ -19,7 +19,7 @@ struct module_manager {
 
 static struct module *find_module(const SYMBOL module_name,
                                   const SYMBOL submodule_name,
-                                  int for_submodule)
+                                  bool for_submodule)
 {
     struct module *mp;
     assert(module_name != NULL);
@@ -271,7 +271,7 @@ int export_submodule(SYMBOL submod_name, SYMBOL mod_name, ID ids,
 
 static int import_intermediate_file(const SYMBOL name,
                                     const SYMBOL submodule_name,
-                                    struct module **pmod, int as_for_submodule)
+                                    struct module **pmod, bool as_for_submodule)
 {
     struct module *mod;
     const char *extension;
@@ -304,7 +304,7 @@ static int import_intermediate_file(const SYMBOL name,
  */
 int import_module(const SYMBOL name, struct module **pmod)
 {
-    return import_intermediate_file(name, NULL, pmod, FALSE);
+    return import_intermediate_file(name, NULL, pmod, false);
 }
 
 /**
@@ -313,7 +313,7 @@ int import_module(const SYMBOL name, struct module **pmod)
 int import_submodule(const SYMBOL module_name, const SYMBOL submodule_name,
                      struct module **pmod)
 {
-    return import_intermediate_file(module_name, submodule_name, pmod, TRUE);
+    return import_intermediate_file(module_name, submodule_name, pmod, true);
 }
 
 void include_module_file(FILE *fp, SYMBOL mod_name)
@@ -322,7 +322,7 @@ void include_module_file(FILE *fp, SYMBOL mod_name)
     FILE *mod_fp;
     int ch;
 
-    mod = find_module(mod_name, NULL, FALSE);
+    mod = find_module(mod_name, NULL, false);
     if (mod == NULL || mod->filepath == NULL)
         return;
     if ((mod_fp = fopen(mod->filepath, "r")) == NULL) {

--- a/F-FrontEnd/src/module-manager.c
+++ b/F-FrontEnd/src/module-manager.c
@@ -152,17 +152,17 @@ static void intermediate_file_name(sds_string* filename,
                                    const struct module *mod,
                                    const char *extension)
 {
-	const size_t modincludeDirvI = vector_size(xmod_inc_dir_paths());
-	char** const modincludeDirv = (char** const)xmod_inc_dir_paths();
+    const size_t modincludeDirvI = vector_size(xmod_inc_dir_paths());
+    char** const modincludeDirv = (char** const)xmod_inc_dir_paths();
 
     sds_string tmp = sdsempty();
     if (modincludeDirvI > 0) {
-    	*filename = sdscatprintf(*filename, "%s/", modincludeDirv[0]);
+        *filename = sdscatprintf(*filename, "%s/", modincludeDirv[0]);
     }
     if (MODULE_IS_MODULE(mod)) {
         tmp = sdscatprintf(tmp, "%s.%s", SYM_NAME(MODULE_NAME(mod)), extension);
     } else { /* mod is submodule */
-    	tmp = sdscatprintf(tmp, "%s:%s.%s",
+        tmp = sdscatprintf(tmp, "%s:%s.%s",
                  SYM_NAME(SUBMODULE_ANCESTOR(mod)),
                  SYM_NAME(SUBMODULE_NAME(mod)), extension);
     }
@@ -188,8 +188,8 @@ bool export_xmod(struct module *mod)
     if (mod != NULL) {
         sds_string filename = sdsempty();
         xmod_file_name(&filename, mod);
-    	const bool res = output_module_file(mod, filename);
-    	sdsfree(filename);
+        const bool res = output_module_file(mod, filename);
+        sdsfree(filename);
         return res;
     } else {
         return false;
@@ -204,9 +204,9 @@ bool export_xsmod(struct module *mod)
     if (mod != NULL) {
         sds_string filename = sdsempty();
         xsmod_file_name(&filename, mod);
-    	const bool res = output_module_file(mod, filename);
-		sdsfree(filename);
-		return res;
+        const bool res = output_module_file(mod, filename);
+        sdsfree(filename);
+        return res;
     } else {
         return false;
     }
@@ -319,16 +319,23 @@ int import_submodule(const SYMBOL module_name, const SYMBOL submodule_name,
 void include_module_file(FILE *fp, SYMBOL mod_name)
 {
     struct module *mod;
-    FILE *mod_fp;
+    FILE *mod_fp = NULL;
     int ch;
 
     mod = find_module(mod_name, NULL, false);
     if (mod == NULL || mod->filepath == NULL)
         return;
-    if ((mod_fp = fopen(mod->filepath, "r")) == NULL) {
-        fatal("cannon open xmod file '%s'", mod->filepath);
+    if(!(ctx->files_cache && (mod_fp = io_cache_get_input_file(ctx->files_cache, mod->filepath))))
+    {
+        if ((mod_fp = fopen(mod->filepath, "r")) == NULL) {
+            fatal("cannon open xmod file '%s'", mod->filepath);
+        }
     }
     while ((ch = getc(mod_fp)) != EOF)
         putc(ch, fp);
+    if(mod_fp)
+    {
+        fclose(mod_fp);
+    }
     return;
 }

--- a/F-FrontEnd/src/module-manager.h
+++ b/F-FrontEnd/src/module-manager.h
@@ -37,7 +37,7 @@ struct module {
     ID head;               /* public elements of this module. */
     ID last;
     int is_intrinsic;  /* TRUE if this module is an intrinsic module. */
-    int for_submodule; /* module for submodule */
+    bool for_submodule; /* module for submodule */
     char *filepath;    /* path for module file */
 };
 

--- a/F-FrontEnd/src/tests-runner.py
+++ b/F-FrontEnd/src/tests-runner.py
@@ -270,7 +270,7 @@ class TestcaseRunner:
             dep_xml_file = join_path(self.working_dir, dep_xml_file_basename)
             # Generate xmod files
             frontend_dep_args = [self.args.frontend] + list(self.frontend_opts) + ['-I', '.', '-I', self.input_dir] + \
-                                [dep, '-o', dep_xml_file_basename]
+                                ['-o', dep_xml_file_basename, dep]
             p = self.__run_exec(frontend_dep_args, TestCaseStageID.DEPENDENCIES_PREP, True)
             if p.returncode != 0:
                 return self.__result
@@ -298,7 +298,7 @@ class TestcaseRunner:
 
     def __test_frontend(self) -> Optional[TestCaseResult]:
         frontend_args = [self.args.frontend] + list(self.frontend_opts) + ['-I', '.', '-I', self.input_dir] +\
-                        [self.test_case, '-o', self.xml_out_file_basename]
+                        ['-o', self.xml_out_file_basename, self.test_case]
         self.__run_exec(frontend_args, TestCaseStageID.FRONTEND)
         return self.__result
 

--- a/F-FrontEnd/src/xcodeml-parse.c
+++ b/F-FrontEnd/src/xcodeml-parse.c
@@ -162,9 +162,21 @@ XcodeMLNode *xcodeml_ParseFile(const char *fileName)
     xmlNode *rootNode = NULL;
     bool succeeded = false;
 
-    doc =
-        xmlReadFile(fileName, NULL,
-                    XML_PARSE_NOBLANKS | XML_PARSE_NONET | XML_PARSE_NOWARNING);
+    {
+        void* startAddress = NULL;
+        size_t size = 0;
+
+          if(ctx->files_cache && io_cache_get_input_file_as_mem(ctx->files_cache, fileName, &startAddress, &size))
+        {
+              doc = xmlReadMemory((const char *)startAddress, size, NULL, NULL,
+                              XML_PARSE_NOBLANKS | XML_PARSE_NONET | XML_PARSE_NOWARNING);
+        }
+        else
+        {
+            doc = xmlReadFile(fileName, NULL,
+                                          XML_PARSE_NOBLANKS | XML_PARSE_NONET | XML_PARSE_NOWARNING);
+        }
+    }
 
     if (!doc) {
 

--- a/F-FrontEnd/src/xcodeml-traverse.c
+++ b/F-FrontEnd/src/xcodeml-traverse.c
@@ -148,7 +148,7 @@ int xcodeml_has_symbol(const char *symbol)
  * module.
  *
  * @param module_filename the file name of XcodeML.
- * @param fortran_filename the file name wrriten the declarations inside the
+ * @param fortran_filename the file name written the declarations inside the
  * module.
  * @return returns 0 if fail to read XcodeML, otherwise returns 1.
  */


### PR DESCRIPTION
Should be applied after https://github.com/omni-compiler/xcodeml-tools/pull/181
Makes it possible to avoid using filesystem IO inside FFront C code, when using Java bindings. 
Does not affect original FFront C build.